### PR TITLE
Ignore script elements when locating the DOI

### DIFF
--- a/public/js/bookmarklet.js
+++ b/public/js/bookmarklet.js
@@ -24,6 +24,10 @@
         continue;
       }
 
+      if (node.nodeName == "SCRIPT") {
+        continue;
+      }
+
       for (j = 0; j < node.childNodes.length; j++) {
         childNode = node.childNodes[j];
 


### PR DESCRIPTION
Text nodes in `<script>` elements can contain the DOI, but also other characters which can't be distinguished from the DOI; there's usually a better place to read the DOI from.
