### PR TITLE
Remember the user's details

### DIFF
--- a/public/js/add.js
+++ b/public/js/add.js
@@ -16,6 +16,59 @@ function showPosition(position) {
 
 getLocation();
 
+// save details in localstorage
+function rememberDetails() {
+  var rememberMeInput = $('#id_remember');
+  var rememberNodes = $('[data-remember]');
+  var remember = false;
+
+  // test for localstorage support (from Modernizr)
+  // fails if third-party data is not allowed (in an iframe)
+  try {
+      localStorage.setItem('test', 'test');
+      localStorage.removeItem('test');
+  } catch(e) {
+      rememberMeInput.prop('checked', false).parent().hide();
+      return;
+  }
+
+  // can't store booleans in localstorage, so "false" (string) = "don't store"
+  remember = localStorage.getItem('id_remember') !== 'false';
+  rememberMeInput.prop('checked', remember);
+
+  // store/load details
+  rememberNodes
+    // save the details
+    .on('change', function(){
+      if (!remember) {
+        return;
+      }
+
+      localStorage.setItem(this.getAttribute('id'), $(this).val());
+    })
+    // load the details
+    .each(function() {
+      $(this).val(localStorage.getItem(this.getAttribute('id')));
+    });
+
+  // when "remember me" is unchecked, delete stored details
+  rememberMeInput.on('change', function() {
+    remember = rememberMeInput.prop('checked');
+    localStorage.setItem('id_remember', remember);
+
+    if (remember) {
+      // save the current values
+      rememberNodes.trigger('change');
+    } else {
+      // remove the stored values
+      rememberNodes.each(function() {
+        localStorage.removeItem(this.getAttribute('id'));
+      });
+    }
+  });
+};
+
+rememberDetails();
 
 $(function() {
   $('form').submit(function() {

--- a/public/js/add.js
+++ b/public/js/add.js
@@ -18,23 +18,28 @@ getLocation();
 
 // save details in localstorage
 function rememberDetails() {
-  var rememberMeInput = $('#id_remember');
-  var rememberNodes = $('[data-remember]');
-  var remember = false;
-
   // test for localstorage support (from Modernizr)
   // fails if third-party data is not allowed (in an iframe)
   try {
       localStorage.setItem('test', 'test');
       localStorage.removeItem('test');
   } catch(e) {
-      rememberMeInput.prop('checked', false).parent().hide();
       return;
   }
 
-  // can't store booleans in localstorage, so "false" (string) = "don't store"
-  remember = localStorage.getItem('id_remember') !== 'false';
-  rememberMeInput.prop('checked', remember);
+  var rememberMeInput = $('#id_remember'),
+      rememberNodes = $('[data-remember]');
+
+  var stored = localStorage.getItem('id_remember');
+
+  // can't always store booleans in localstorage, so "false" (string) = "don't store"
+  var remember = stored === null || stored === true || stored.toString() === 'true';
+
+  if (remember) {
+    rememberMeInput.prop('checked', true);
+  }
+
+  rememberMeInput.parent().show();
 
   // store/load details
   rememberNodes

--- a/views/Event/add_iframe.jade
+++ b/views/Event/add_iframe.jade
@@ -15,8 +15,8 @@ block content
         .controls
           input#id_profession.input-block-level(type='text', name='profession', placeholder='e.g. Doctor', data-remember)
 
-    label.checkbox(for='id_remember') Remember me
-      input#id_remember.input-block-level(type='checkbox', name='remember', checked)
+    label.checkbox(for='id_remember', style='display:none') Remember me
+      input#id_remember.input-block-level(type='checkbox', name='remember')
 
     .control-group
       label.control-label(for='id_location') Location

--- a/views/Event/add_iframe.jade
+++ b/views/Event/add_iframe.jade
@@ -8,12 +8,15 @@ block content
     .control-group
       label.control-label(for='id_name') Your name
       .controls
-        input#id_name.input-block-level(type='text', name='name', placeholder='e.g. Dr John Doe')
+        input#id_name.input-block-level(type='text', name='name', placeholder='e.g. Dr John Doe', data-remember)
 
     .control-group
         label.control-label(for='id_profession') Profession
         .controls
-          input#id_profession.input-block-level(type='text', name='profession', placeholder='e.g. Doctor')
+          input#id_profession.input-block-level(type='text', name='profession', placeholder='e.g. Doctor', data-remember)
+
+    label.checkbox(for='id_remember') Remember me
+      input#id_remember.input-block-level(type='checkbox', name='remember', checked)
 
     .control-group
       label.control-label(for='id_location') Location


### PR DESCRIPTION
Store the input data (name, profession) in localStorage, if available.

Note: if third-party data storage has been blocked by the user, localStorage (and cookies) isn't available in an iframe. May want to consider opening in a pop-up window instead.
