### PR TITLE
Remove rogue colon in stories.jade. Fixes #40.

### DIFF
--- a/views/stories.jade
+++ b/views/stories.jade
@@ -9,4 +9,5 @@ block content
       blockquote #{event.story}
       small
         em= event.accessed.calendar()
-        span: #{event.profession}  from #{event.location}
+        | 
+        span #{event.profession}  from #{event.location}


### PR DESCRIPTION
Hopefully this should sort out the bonus HTML tags appearing on the stories page.
