### PR TITLE
Add support to search CORE for fulltext.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ python:
 install: pip install -r requirements.txt --use-mirrors
 script:
   - "flake8"
-  - "python manage.py test web bookmarklet"
+  - "python manage.py test web bookmarklet metadata"

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -27,6 +27,17 @@ flake8 --install-hook                # Install the flake8 pre-commit hook
                                      # Checks your code for PEP8 compliance
 ```
 
+### Set your CORE API key
+
+```
+export CORE_API_KEY=blahblahblah
+```
+
+If you don't have a key, the app will still run, but you'll get
+warnings and communications with [CORE](http://core.kmi.open.ac.uk/)
+will fail.  An API key isn't required to run the tests, as the API
+accesses are mocked out.
+
 ### Start mongodb
 
 If the mongodb daemon is not running yet, you can start it locally with

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,4 @@ build:
 
 
 test:
-	python manage.py test web bookmarklet
+	python manage.py test web bookmarklet metadata

--- a/oabutton/apps/bookmarklet/templates/bookmarklet/layout.html
+++ b/oabutton/apps/bookmarklet/templates/bookmarklet/layout.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="/static/css/font-awesome.min.css">
     <link rel="stylesheet" href="/static/css/app.css">
   </head>
-  <body style="margin-top: 20px">
+  <body style="margin-top: 20px" {% block body_attrs %}{% endblock %}>
     <!-- Main body-->
     <div class="container">{% block content %}{% endblock %}
     </div>

--- a/oabutton/apps/bookmarklet/templates/bookmarklet/success.html
+++ b/oabutton/apps/bookmarklet/templates/bookmarklet/success.html
@@ -4,6 +4,6 @@
 <ul id="oa_links">
 </ul>
 {% endblock %}
-{%- block scripts %}
+{% block scripts %}
 <script src="/static/js/success.js"></script>{% endblock %}
-{%- block body_attrs %}data-doi="{{doi|urlencode}}"{% endblock %}
+{% block body_attrs %}data-doi="{{doi|urlencode}}"{% endblock %}

--- a/oabutton/apps/bookmarklet/templates/bookmarklet/success.html
+++ b/oabutton/apps/bookmarklet/templates/bookmarklet/success.html
@@ -3,6 +3,9 @@
 <p>Now to find an Open Access version…</p>
 <ul id="oa_links">
 </ul>
+<div>
+<a href="http://en.wikipedia.org/wiki/Digital_object_identifier">What's a DOI?</a>
+</div>
 {% endblock %}
 {% block scripts %}
 <script src="/static/js/success.js"></script>{% endblock %}

--- a/oabutton/apps/bookmarklet/templates/bookmarklet/success.html
+++ b/oabutton/apps/bookmarklet/templates/bookmarklet/success.html
@@ -1,6 +1,9 @@
 {% extends "bookmarklet/layout.html" %}{% block content %}
 <h2>Thanks!</h2>
 <p>Now to find an Open Access version…</p>
-{% if scholar_url %}
-<a id="id_scholar" title="Find in Google Scholar" target="_blank" href="{{ scholar_url }}"><img src="/static/img/scholar.png"/>Search Google Scholar</a>
-{% endif %}{% endblock %}
+<ul id="oa_links">
+</ul>
+{% endblock %}
+{%- block scripts %}
+<script src="/static/js/success.js"></script>{% endblock %}
+{%- block body_attrs %}data-doi="{{doi|urlencode}}"{% endblock %}

--- a/oabutton/apps/bookmarklet/tests.py
+++ b/oabutton/apps/bookmarklet/tests.py
@@ -13,6 +13,7 @@ from oabutton.apps.bookmarklet.models import Event
 from oabutton.apps.bookmarklet.views import convert_post
 from oabutton.json_util import MyEncoder
 import json
+import re
 
 
 @override_settings(MONGO_DB=MagicMock())
@@ -67,3 +68,27 @@ class SimpleTest(TestCase):
         for k in POST_DATA:
             assert k in MONGO_DATA
         assert MONGO_DATA['coords'] == {'lat': '33.2', 'lng': '21.9'}
+
+    def test_add_success_response(self):
+        '''
+        Tests to make sure the response to submitting the form is rendered
+        correctly.
+        '''
+        POST_DATA = {'name': 'mock name',
+                     'profession': 'mock profession',
+                     'location': 'mock location',
+                     'coords': '33.2,21.9',
+                     'accessed': '2013-09-07T04:21:02.407511',
+                     'pub_date': '2013-10-07T04:21:02.407511',
+                     'doi': 'some.doi',
+                     'url': 'http://some.url/some_path',
+                     'story': 'some_story',
+                     'email': 'foo@blah.com'}
+
+        c = Client()
+        response = c.post('/api/post/', POST_DATA)
+
+        # Check that the DOI is passed through correctly
+        data_doi_re = re.compile('<body [^>]*data-doi="%s">'
+                                 % POST_DATA['doi'])
+        assert data_doi_re.search(response.content) is not None

--- a/oabutton/apps/bookmarklet/views.py
+++ b/oabutton/apps/bookmarklet/views.py
@@ -93,4 +93,3 @@ def add_post(req):
     c = {'doi': req.POST['doi']}
 
     return render_to_response('bookmarklet/success.html', c)
-

--- a/oabutton/apps/bookmarklet/views.py
+++ b/oabutton/apps/bookmarklet/views.py
@@ -90,8 +90,7 @@ def add_post(req):
     except Exception, e:
         return HttpResponseServerError(e)
 
-    scholar_url = ''
-    if req.POST['doi']:
-        scholar_url = 'http://scholar.google.com/scholar?cluster=http://dx.doi.org/%s' % req.POST[
-            'doi']
-    return render_to_response('bookmarklet/success.html', {'scholar_url': scholar_url})
+    c = {'doi': req.POST['doi']}
+
+    return render_to_response('bookmarklet/success.html', c)
+

--- a/oabutton/apps/metadata/tests.py
+++ b/oabutton/apps/metadata/tests.py
@@ -1,0 +1,58 @@
+"""
+This file demonstrates writing tests using the unittest module. These will pass
+when you run "manage.py test".
+
+Replace this with more appropriate tests for your application.
+"""
+
+from django.test import TestCase
+from django.test.client import Client
+import httpretty
+import os
+import json
+
+
+SAMPLE_ARTHRITIS = r'''{"ListRecords":[{"total_hits":5015},{"record":{"header":{"header:content":{"core:repositoryIdentifier":"143","identifier":"669636"},"header:attr":{"xmlns:core":"http:\/\/core.kmi.open.ac.uk\/api\/doc"}},"metadata":{"oai_dc:dc":{"oai_dc:ns":[{"xmlns:oai_dc":"http:\/\/www.openarchives.org\/OAI\/2.0\/oai_dc\/","xmlns:dc":"http:\/\/purl.org\/dc\/elements\/1.1\/"}],"dc:creator":"R Kudyar","dc:format":"application\/pdf","dc:source":"http:\/\/www.jkscience.org\/archive\/111\/18-RL-JACORD%20ARTHRITIS.pdf","dc:date":"2009","dc:identifier":"http:\/\/www.jkscience.org\/archive\/111\/18-RL-JACORD%20ARTHRITIS.pdf","dc:description":"A case of a patient with rheumatic valvulardisease who had comparable deformities of the handsand fingers and who fulfilled all of the criteriasuggested by Bywaters to describe Jaccoud's Arthritis is decribed here.","dc:title":"Jaccoud\u2019s Arthritis"}}}},{"record":{"header":{"header:content":{"core:repositoryIdentifier":"140","identifier":"60225"},"header:attr":{"xmlns:core":"http:\/\/core.kmi.open.ac.uk\/api\/doc"}},"metadata":{"oai_dc:dc":{"oai_dc:ns":[{"xmlns:oai_dc":"http:\/\/www.openarchives.org\/OAI\/2.0\/oai_dc\/","xmlns:dc":"http:\/\/purl.org\/dc\/elements\/1.1\/"}],"dc:creator":"Zai Liu, Guo Deng, Simon Foster and Andrej Tarkowski","dc:format":"application\/pdf","dc:source":"http:\/\/eprints.whiterose.ac.uk\/21\/1\/ar330.pdf","dc:date":"2001-09-17","dc:identifier":"http:\/\/eprints.whiterose.ac.uk\/21\/1\/ar330.pdf","dc:description":"Staphylococcus aureus is one of the most important pathogens in septic arthritis. To analyse the arthritogenic properties of staphylococcal peptidoglycan (PGN), highly purified PGN from S. aureus was intra-articularly injected into murine joints. The results demonstrate that PGN will trigger arthritis in a dose-dependent manner. A single injection of this compound leads to massive infiltration of predominantly macrophages and polymorphonuclear cells with occasional signs of cartilage and\/or bone destruction, lasting for at least 14 days. Further studies showed that this condition is mediated by the combined impact of acquired and innate immune systems. Our results indicate that PGN exerts a central role in joint inflammation triggered by S. aureus.","dc:title":"Staphylococcal peptidoglycans induce arthritis"}}}},{"record":{"header":{"header:content":{"core:repositoryIdentifier":"143","identifier":"5726004"},"header:attr":{"xmlns:core":"http:\/\/core.kmi.open.ac.uk\/api\/doc"}},"metadata":{"oai_dc:dc":{"oai_dc:ns":[{"xmlns:oai_dc":"http:\/\/www.openarchives.org\/OAI\/2.0\/oai_dc\/","xmlns:dc":"http:\/\/purl.org\/dc\/elements\/1.1\/"}],"dc:creator":"Karambin Mohammad Mehdi and Hashemian Hooman","dc:format":"application\/pdf","dc:source":"http:\/\/journals.tums.ac.ir\/PdfMed.aspx?pdf_med=\/upload_files\/pdf\/12751.pdf&manuscript_id=12751","dc:date":"2009","dc:identifier":"http:\/\/journals.tums.ac.ir\/PdfMed.aspx?pdf_med=\/upload_files\/pdf\/12751.pdf&manuscript_id=12751","dc:description":"To determine the rate of different types of arthritis in children. We prepared a retrospective descriptive study and included the whole 100 cases of arthritis referred to 17-Shahrivar Hospital, Rasht, Guilan during a 3 years period. Using their medical files, data including age, sex, season of admission, history of trauma, signs and symptoms, lab findings and duration of hospitalization were collected. SPSS 13.0 (statistical software) applied for statistical analysis. The most common age of involvement ranged 6-9 years. Septic arthritis, brucellosis, and rheumatoid fever were the most frequent causes of arthritis in our study. Fever and restricted range of motion had the highest rate among different signs and symptoms. Lab data demonstrated leukocytosis, positive CRP, and increased ESR among 74, 79.5, and 73 percent of our patients, respectively. According to the high prevalence of septic arthritis and the arthritis due to brucellosis and rheumatoid fever, it seems that mentioned diseases are still major problems in the issue of hygiene management.","dc:title":"Childhood Arthritis: Rate of Different Types"}}}}]}'''
+
+
+class SimpleTest(TestCase):
+
+    def setUp(self):
+        os.environ['CORE_API_KEY'] = 'Not really an API key'
+
+    @httpretty.activate
+    def test_core_search_success(self):
+        """
+        Test that a successful request is proxied correctly
+        """
+        httpretty.register_uri(
+            httpretty.GET,
+            "http://core.kmi.open.ac.uk/api/search/arthritis",
+            body=SAMPLE_ARTHRITIS)
+
+        c = Client()
+        response = c.get('/metadata/coresearch.json/arthritis')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, SAMPLE_ARTHRITIS)
+
+    @httpretty.activate
+    def test_core_search_failure(self):
+        """
+        Test that a failed request is passed on
+        """
+        httpretty.register_uri(
+            httpretty.GET,
+            "http://core.kmi.open.ac.uk/api/search/arthritis",
+            body='ERROR',
+            status=418)
+
+        c = Client()
+        response = c.get('/metadata/coresearch.json/arthritis')
+
+        self.assertEqual(response.status_code, 502)
+
+        response_info = json.loads(response.content)
+        self.assertTrue('error' in response_info)
+        self.assertEqual(response_info['error']['status'], 418)
+        self.assertEqual(response_info['error']['content'], 'ERROR')

--- a/oabutton/apps/metadata/urls.py
+++ b/oabutton/apps/metadata/urls.py
@@ -1,0 +1,6 @@
+from django.conf.urls import patterns, url
+
+from views import core_search
+
+urlpatterns = patterns('',
+                       url(r'^coresearch.json/(.*)$', core_search, name='core-search'))

--- a/oabutton/apps/metadata/views.py
+++ b/oabutton/apps/metadata/views.py
@@ -1,0 +1,37 @@
+from django.http import HttpResponse
+from os import environ
+import requests
+import logging
+import json
+
+CORE_API_BASE = 'http://core.kmi.open.ac.uk/api'
+CORE_API_SEARCH = CORE_API_BASE + '/search/'
+CORE_API_KEY = environ['CORE_API_KEY']
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+
+def core_search(req, query):
+    parameters = req.GET.copy()
+    parameters['api_key'] = CORE_API_KEY
+    parameters['format'] = 'json'
+
+    query_url = CORE_API_SEARCH + query
+
+    logger.debug(query_url)
+
+    r = requests.get(query_url, params=parameters)
+
+    logger.debug('Response from CORE: %i', r.status_code)
+
+    if r.status_code == requests.codes.ok:
+        return HttpResponse(r.text, content_type='application/json')
+    else:
+        error_info = {'error': {
+            'status': r.status_code,
+            'content': r.text
+        }}
+        return HttpResponse(json.dumps(error_info),
+                            content_type='application/json',
+                            status=requests.codes.bad_gateway)

--- a/oabutton/apps/metadata/views.py
+++ b/oabutton/apps/metadata/views.py
@@ -4,12 +4,15 @@ import requests
 import logging
 import json
 
+logger = logging.getLogger(__name__)
+
 CORE_API_BASE = 'http://core.kmi.open.ac.uk/api'
 CORE_API_SEARCH = CORE_API_BASE + '/search/'
-CORE_API_KEY = environ['CORE_API_KEY']
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+if 'CORE_API_KEY' in environ:
+    CORE_API_KEY = environ['CORE_API_KEY']
+else:
+    logger.warn("CORE_API_KEY not set in environment: using default value")
+    CORE_API_KEY = '01234567890abcdefghijklmnopqrstu'
 
 
 def core_search(req, query):

--- a/oabutton/settings.py
+++ b/oabutton/settings.py
@@ -185,12 +185,25 @@ INSTALLED_APPS = (
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
+    'formatters': {
+        'verbose': {
+            'format': '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s'
+        },
+        'simple': {
+            'format': '%(levelname)s %(message)s'
+        },
+    },
     'filters': {
         'require_debug_false': {
             '()': 'django.utils.log.RequireDebugFalse'
         }
     },
     'handlers': {
+        'console': {
+            'level': 'WARN',
+            'class': 'logging.StreamHandler',
+            'formatter': 'verbose'
+        },
         'mail_admins': {
             'level': 'ERROR',
             'filters': ['require_debug_false'],
@@ -202,6 +215,10 @@ LOGGING = {
             'handlers': ['mail_admins'],
             'level': 'ERROR',
             'propagate': True,
+        },
+        'oabutton.apps.metadata.views': {
+            'handlers': ['console'],
+            'level': 'WARN',
         },
     }
 }

--- a/oabutton/settings.py
+++ b/oabutton/settings.py
@@ -173,6 +173,8 @@ INSTALLED_APPS = (
 
     # The web app is the main website
     'oabutton.apps.web',
+
+    'oabutton.apps.metadata',
 )
 
 # A sample logging configuration. The only tangible logging

--- a/oabutton/static/public/js/add.js
+++ b/oabutton/static/public/js/add.js
@@ -18,33 +18,6 @@ $(function() {
 
   getLocation();
 
-  function pmc() {
-    var doi = $('#id_doi').val();
-
-    if (doi) {
-      $.ajax({
-          url: 'http://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi',
-          data: {
-            db: "pmc",
-            retmax: 1,
-            term: doi + "[DOI]",
-            tool: "oabutton"
-          },
-          dataType: "xml",
-          success: function(response) {
-            if (response.getElementsByTagName('Count')[0].textContent === '0') {
-              return;
-            }
-
-            var pmcid = response.getElementsByTagName('Id')[0].textContent;
-            var url = "http://www.ncbi.nlm.nih.gov/pmc/articles/PMC" + pmcid + "/";
-            $("#id_pmc").attr("href", url).show();
-          }
-      });
-    }
-  }
-
-  pmc();
 
   function parseCrossRef(entry) {
     var description = [],

--- a/oabutton/static/public/js/success.js
+++ b/oabutton/static/public/js/success.js
@@ -1,0 +1,60 @@
+$(function() {
+
+  function addPubMedCentralLink() {
+    var doi = $('body').data('doi');
+
+    if (doi) {
+      $.ajax({
+          url: 'http://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi',
+          data: {
+            db: "pmc",
+            retmax: 1,
+            term: doi + "[DOI]",
+            tool: "oabutton"
+          },
+          dataType: "xml",
+          success: function(response) {
+            if (response.getElementsByTagName('Count')[0].textContent === '0') {
+              return;
+            }
+
+            var pmcid = response.getElementsByTagName('Id')[0].textContent;
+            var url = "http://www.ncbi.nlm.nih.gov/pmc/articles/PMC" + pmcid + "/";
+            // $("#id_pmc").attr("href", url).show();
+  	    var pmc_link = document.createElement("a");
+	    pmc_link.setAttribute("href", url);
+	    pmc_link.setAttribute("target", "_blank");
+	    pmc_link.innerHTML = "View on PubMedCentral";
+
+	    var li = document.createElement("li");
+	    li.appendChild(pmc_link);
+
+  	    $("#oa_links").append(li);
+          }
+      });
+    }
+  }
+
+  addPubMedCentralLink();
+
+  function addScholarLink() {
+    var doi = $('body').data('doi');
+
+    if (doi) {
+      var url = 'http://scholar.google.com/scholar?cluster=' + encodeURIComponent('http://dx.doi.org/' + doi);
+      //$('#id_scholar').attr('href', url).show();
+      var sch_link = document.createElement("a");
+      sch_link.setAttribute("href", url);
+      sch_link.setAttribute("target", "_blank");
+      sch_link.innerHTML = "Search with Google Scholar";
+
+      var li = document.createElement("li");
+      li.appendChild(sch_link);
+
+      $("#oa_links").append(li);
+    }
+  }
+
+  addScholarLink();
+
+});

--- a/oabutton/static/public/js/success.js
+++ b/oabutton/static/public/js/success.js
@@ -1,4 +1,4 @@
-$(function() {
+var oabSuccess = (function($) {
 
   function parseCrossRef(entry, doi) {
     var metadata = {'doi': doi},
@@ -47,8 +47,6 @@ $(function() {
       });
     }
   }
-
-  lookupCrossRef();
 
   function addPubMedCentralLink(metadata) {
     var doi = metadata["doi"];
@@ -121,4 +119,16 @@ $(function() {
   }
 
 
+  return {
+    parseCrossRef: parseCrossRef,
+    lookupCrossRef: lookupCrossRef,
+    addScholarDOILink: addScholarDOILink,
+    addScholarTitleLink: addScholarTitleLink,
+  };
+
+})(jQuery);
+
+
+$(document).ready(function() {
+  oabSuccess.lookupCrossRef();
 });

--- a/oabutton/static/public/js/success.js
+++ b/oabutton/static/public/js/success.js
@@ -42,6 +42,7 @@ var oabSuccess = (function($) {
               addPubMedCentralLink(metadata);
               addScholarDOILink(metadata);
               addScholarTitleLink(metadata);
+              discoverCORELinks(metadata);
             }
           }
       });
@@ -118,12 +119,41 @@ var oabSuccess = (function($) {
     }
   }
 
+  function discoverCORELinks(metadata) {
+    var title = metadata["title"];
+
+    if (title) {
+      $.ajax({
+        url: "/metadata/coresearch.json/title:(" + encodeURIComponent(title) + ")",
+        dataType: 'json',
+        success: function(response) {
+	  var records = response.ListRecords;
+	  var $list = $('<ul></ul>');
+	  for (var i = 1; i < records.length; i++) {
+	    metadata = records[i]['record']['metadata']['oai_dc:dc'];
+	    $list.append('<li><a href="'
+			 + metadata['dc:identifier']
+			 + '">'
+			 + metadata['dc:creator']
+			 + ' (' + metadata['dc:date'] + '); '
+			 + metadata['dc:title']
+			 + '</a></li>');
+	  }
+
+	  $li = $('<li>Matches from CORE repository:</li>');
+	  $li.append($list);
+	  $("#oa_links").append($li);
+        }
+      });
+    }
+  }
 
   return {
     parseCrossRef: parseCrossRef,
     lookupCrossRef: lookupCrossRef,
     addScholarDOILink: addScholarDOILink,
     addScholarTitleLink: addScholarTitleLink,
+    discoverCORELinks: discoverCORELinks,
   };
 
 })(jQuery);

--- a/oabutton/static/test/resources/jquery.mockjax.js
+++ b/oabutton/static/test/resources/jquery.mockjax.js
@@ -1,0 +1,587 @@
+/*!
+ * MockJax - jQuery Plugin to Mock Ajax requests
+ *
+ * Version:  1.5.2
+ * Released:
+ * Home:   http://github.com/appendto/jquery-mockjax
+ * Author:   Jonathan Sharp (http://jdsharp.com)
+ * License:  MIT,GPL
+ *
+ * Copyright (c) 2011 appendTo LLC.
+ * Dual licensed under the MIT or GPL licenses.
+ * http://appendto.com/open-source-licenses
+ */
+(function($) {
+	var _ajax = $.ajax,
+		mockHandlers = [],
+		mockedAjaxCalls = [],
+		CALLBACK_REGEX = /=\?(&|$)/,
+		jsc = (new Date()).getTime();
+
+
+	// Parse the given XML string.
+	function parseXML(xml) {
+		if ( window.DOMParser == undefined && window.ActiveXObject ) {
+			DOMParser = function() { };
+			DOMParser.prototype.parseFromString = function( xmlString ) {
+				var doc = new ActiveXObject('Microsoft.XMLDOM');
+				doc.async = 'false';
+				doc.loadXML( xmlString );
+				return doc;
+			};
+		}
+
+		try {
+			var xmlDoc = ( new DOMParser() ).parseFromString( xml, 'text/xml' );
+			if ( $.isXMLDoc( xmlDoc ) ) {
+				var err = $('parsererror', xmlDoc);
+				if ( err.length == 1 ) {
+					throw('Error: ' + $(xmlDoc).text() );
+				}
+			} else {
+				throw('Unable to parse XML');
+			}
+			return xmlDoc;
+		} catch( e ) {
+			var msg = ( e.name == undefined ? e : e.name + ': ' + e.message );
+			$(document).trigger('xmlParseError', [ msg ]);
+			return undefined;
+		}
+	}
+
+	// Trigger a jQuery event
+	function trigger(s, type, args) {
+		(s.context ? $(s.context) : $.event).trigger(type, args);
+	}
+
+	// Check if the data field on the mock handler and the request match. This
+	// can be used to restrict a mock handler to being used only when a certain
+	// set of data is passed to it.
+	function isMockDataEqual( mock, live ) {
+		var identical = true;
+		// Test for situations where the data is a querystring (not an object)
+		if (typeof live === 'string') {
+			// Querystring may be a regex
+			return $.isFunction( mock.test ) ? mock.test(live) : mock == live;
+		}
+		$.each(mock, function(k) {
+			if ( live[k] === undefined ) {
+				identical = false;
+				return identical;
+			} else {
+				// This will allow to compare Arrays 
+				if ( typeof live[k] === 'object' && live[k] !== null ) {
+					identical = identical && isMockDataEqual(mock[k], live[k]);
+				} else {
+					if ( mock[k] && $.isFunction( mock[k].test ) ) {
+						identical = identical && mock[k].test(live[k]);
+					} else {
+						identical = identical && ( mock[k] == live[k] );
+					}
+				}
+			}
+		});
+
+		return identical;
+	}
+
+	// Check the given handler should mock the given request
+	function getMockForRequest( handler, requestSettings ) {
+		// If the mock was registered with a function, let the function decide if we
+		// want to mock this request
+		if ( $.isFunction(handler) ) {
+			return handler( requestSettings );
+		}
+
+		// Inspect the URL of the request and check if the mock handler's url
+		// matches the url for this ajax request
+		if ( $.isFunction(handler.url.test) ) {
+			// The user provided a regex for the url, test it
+			if ( !handler.url.test( requestSettings.url ) ) {
+				return null;
+			}
+		} else {
+			// Look for a simple wildcard '*' or a direct URL match
+			var star = handler.url.indexOf('*');
+			if (handler.url !== requestSettings.url && star === -1 ||
+					!new RegExp(handler.url.replace(/[-[\]{}()+?.,\\^$|#\s]/g, "\\$&").replace(/\*/g, '.+')).test(requestSettings.url)) {
+				return null;
+			}
+		}
+
+		// Inspect the data submitted in the request (either POST body or GET query string)
+		if ( handler.data && requestSettings.data ) {
+			if ( !isMockDataEqual(handler.data, requestSettings.data) ) {
+				// They're not identical, do not mock this request
+				return null;
+			}
+		}
+		// Inspect the request type
+		if ( handler && handler.type &&
+				handler.type.toLowerCase() != requestSettings.type.toLowerCase() ) {
+			// The request type doesn't match (GET vs. POST)
+			return null;
+		}
+
+		return handler;
+	}
+
+	// Process the xhr objects send operation
+	function _xhrSend(mockHandler, requestSettings, origSettings) {
+
+		// This is a substitute for < 1.4 which lacks $.proxy
+		var process = (function(that) {
+			return function() {
+				return (function() {
+					var onReady;
+
+					// The request has returned
+					this.status     = mockHandler.status;
+					this.statusText = mockHandler.statusText;
+					this.readyState	= 4;
+
+					// We have an executable function, call it to give
+					// the mock handler a chance to update it's data
+					if ( $.isFunction(mockHandler.response) ) {
+						mockHandler.response(origSettings);
+					}
+					// Copy over our mock to our xhr object before passing control back to
+					// jQuery's onreadystatechange callback
+					if ( requestSettings.dataType == 'json' && ( typeof mockHandler.responseText == 'object' ) ) {
+						this.responseText = JSON.stringify(mockHandler.responseText);
+					} else if ( requestSettings.dataType == 'xml' ) {
+						if ( typeof mockHandler.responseXML == 'string' ) {
+							this.responseXML = parseXML(mockHandler.responseXML);
+							//in jQuery 1.9.1+, responseXML is processed differently and relies on responseText
+							this.responseText = mockHandler.responseXML;
+						} else {
+							this.responseXML = mockHandler.responseXML;
+						}
+					} else {
+						this.responseText = mockHandler.responseText;
+					}
+					if( typeof mockHandler.status == 'number' || typeof mockHandler.status == 'string' ) {
+						this.status = mockHandler.status;
+					}
+					if( typeof mockHandler.statusText === "string") {
+						this.statusText = mockHandler.statusText;
+					}
+					// jQuery 2.0 renamed onreadystatechange to onload
+					onReady = this.onreadystatechange || this.onload;
+
+					// jQuery < 1.4 doesn't have onreadystate change for xhr
+					if ( $.isFunction( onReady ) ) {
+						if( mockHandler.isTimeout) {
+							this.status = -1;
+						}
+						onReady.call( this, mockHandler.isTimeout ? 'timeout' : undefined );
+					} else if ( mockHandler.isTimeout ) {
+						// Fix for 1.3.2 timeout to keep success from firing.
+						this.status = -1;
+					}
+				}).apply(that);
+			};
+		})(this);
+
+		if ( mockHandler.proxy ) {
+			// We're proxying this request and loading in an external file instead
+			_ajax({
+				global: false,
+				url: mockHandler.proxy,
+				type: mockHandler.proxyType,
+				data: mockHandler.data,
+				dataType: requestSettings.dataType === "script" ? "text/plain" : requestSettings.dataType,
+				complete: function(xhr) {
+					mockHandler.responseXML = xhr.responseXML;
+					mockHandler.responseText = xhr.responseText;
+					mockHandler.status = xhr.status;
+					mockHandler.statusText = xhr.statusText;
+					this.responseTimer = setTimeout(process, mockHandler.responseTime || 0);
+				}
+			});
+		} else {
+			// type == 'POST' || 'GET' || 'DELETE'
+			if ( requestSettings.async === false ) {
+				// TODO: Blocking delay
+				process();
+			} else {
+				this.responseTimer = setTimeout(process, mockHandler.responseTime || 50);
+			}
+		}
+	}
+
+	// Construct a mocked XHR Object
+	function xhr(mockHandler, requestSettings, origSettings, origHandler) {
+		// Extend with our default mockjax settings
+		mockHandler = $.extend(true, {}, $.mockjaxSettings, mockHandler);
+
+		if (typeof mockHandler.headers === 'undefined') {
+			mockHandler.headers = {};
+		}
+		if ( mockHandler.contentType ) {
+			mockHandler.headers['content-type'] = mockHandler.contentType;
+		}
+
+		return {
+			status: mockHandler.status,
+			statusText: mockHandler.statusText,
+			readyState: 1,
+			open: function() { },
+			send: function() {
+				origHandler.fired = true;
+				_xhrSend.call(this, mockHandler, requestSettings, origSettings);
+			},
+			abort: function() {
+				clearTimeout(this.responseTimer);
+			},
+			setRequestHeader: function(header, value) {
+				mockHandler.headers[header] = value;
+			},
+			getResponseHeader: function(header) {
+				// 'Last-modified', 'Etag', 'content-type' are all checked by jQuery
+				if ( mockHandler.headers && mockHandler.headers[header] ) {
+					// Return arbitrary headers
+					return mockHandler.headers[header];
+				} else if ( header.toLowerCase() == 'last-modified' ) {
+					return mockHandler.lastModified || (new Date()).toString();
+				} else if ( header.toLowerCase() == 'etag' ) {
+					return mockHandler.etag || '';
+				} else if ( header.toLowerCase() == 'content-type' ) {
+					return mockHandler.contentType || 'text/plain';
+				}
+			},
+			getAllResponseHeaders: function() {
+				var headers = '';
+				$.each(mockHandler.headers, function(k, v) {
+					headers += k + ': ' + v + "\n";
+				});
+				return headers;
+			}
+		};
+	}
+
+	// Process a JSONP mock request.
+	function processJsonpMock( requestSettings, mockHandler, origSettings ) {
+		// Handle JSONP Parameter Callbacks, we need to replicate some of the jQuery core here
+		// because there isn't an easy hook for the cross domain script tag of jsonp
+
+		processJsonpUrl( requestSettings );
+
+		requestSettings.dataType = "json";
+		if(requestSettings.data && CALLBACK_REGEX.test(requestSettings.data) || CALLBACK_REGEX.test(requestSettings.url)) {
+			createJsonpCallback(requestSettings, mockHandler, origSettings);
+
+			// We need to make sure
+			// that a JSONP style response is executed properly
+
+			var rurl = /^(\w+:)?\/\/([^\/?#]+)/,
+				parts = rurl.exec( requestSettings.url ),
+				remote = parts && (parts[1] && parts[1] !== location.protocol || parts[2] !== location.host);
+
+			requestSettings.dataType = "script";
+			if(requestSettings.type.toUpperCase() === "GET" && remote ) {
+				var newMockReturn = processJsonpRequest( requestSettings, mockHandler, origSettings );
+
+				// Check if we are supposed to return a Deferred back to the mock call, or just
+				// signal success
+				if(newMockReturn) {
+					return newMockReturn;
+				} else {
+					return true;
+				}
+			}
+		}
+		return null;
+	}
+
+	// Append the required callback parameter to the end of the request URL, for a JSONP request
+	function processJsonpUrl( requestSettings ) {
+		if ( requestSettings.type.toUpperCase() === "GET" ) {
+			if ( !CALLBACK_REGEX.test( requestSettings.url ) ) {
+				requestSettings.url += (/\?/.test( requestSettings.url ) ? "&" : "?") +
+					(requestSettings.jsonp || "callback") + "=?";
+			}
+		} else if ( !requestSettings.data || !CALLBACK_REGEX.test(requestSettings.data) ) {
+			requestSettings.data = (requestSettings.data ? requestSettings.data + "&" : "") + (requestSettings.jsonp || "callback") + "=?";
+		}
+	}
+
+	// Process a JSONP request by evaluating the mocked response text
+	function processJsonpRequest( requestSettings, mockHandler, origSettings ) {
+		// Synthesize the mock request for adding a script tag
+		var callbackContext = origSettings && origSettings.context || requestSettings,
+			newMock = null;
+
+
+		// If the response handler on the moock is a function, call it
+		if ( mockHandler.response && $.isFunction(mockHandler.response) ) {
+			mockHandler.response(origSettings);
+		} else {
+
+			// Evaluate the responseText javascript in a global context
+			if( typeof mockHandler.responseText === 'object' ) {
+				$.globalEval( '(' + JSON.stringify( mockHandler.responseText ) + ')');
+			} else {
+				$.globalEval( '(' + mockHandler.responseText + ')');
+			}
+		}
+
+		// Successful response
+		jsonpSuccess( requestSettings, callbackContext, mockHandler );
+		jsonpComplete( requestSettings, callbackContext, mockHandler );
+
+		// If we are running under jQuery 1.5+, return a deferred object
+		if($.Deferred){
+			newMock = new $.Deferred();
+			if(typeof mockHandler.responseText == "object"){
+				newMock.resolveWith( callbackContext, [mockHandler.responseText] );
+			}
+			else{
+				newMock.resolveWith( callbackContext, [$.parseJSON( mockHandler.responseText )] );
+			}
+		}
+		return newMock;
+	}
+
+
+	// Create the required JSONP callback function for the request
+	function createJsonpCallback( requestSettings, mockHandler, origSettings ) {
+		var callbackContext = origSettings && origSettings.context || requestSettings;
+		var jsonp = requestSettings.jsonpCallback || ("jsonp" + jsc++);
+
+		// Replace the =? sequence both in the query string and the data
+		if ( requestSettings.data ) {
+			requestSettings.data = (requestSettings.data + "").replace(CALLBACK_REGEX, "=" + jsonp + "$1");
+		}
+
+		requestSettings.url = requestSettings.url.replace(CALLBACK_REGEX, "=" + jsonp + "$1");
+
+
+		// Handle JSONP-style loading
+		window[ jsonp ] = window[ jsonp ] || function( tmp ) {
+			data = tmp;
+			jsonpSuccess( requestSettings, callbackContext, mockHandler );
+			jsonpComplete( requestSettings, callbackContext, mockHandler );
+			// Garbage collect
+			window[ jsonp ] = undefined;
+
+			try {
+				delete window[ jsonp ];
+			} catch(e) {}
+
+			if ( head ) {
+				head.removeChild( script );
+			}
+		};
+	}
+
+	// The JSONP request was successful
+	function jsonpSuccess(requestSettings, callbackContext, mockHandler) {
+		// If a local callback was specified, fire it and pass it the data
+		if ( requestSettings.success ) {
+			requestSettings.success.call( callbackContext, mockHandler.responseText || "", status, {} );
+		}
+
+		// Fire the global callback
+		if ( requestSettings.global ) {
+			trigger(requestSettings, "ajaxSuccess", [{}, requestSettings] );
+		}
+	}
+
+	// The JSONP request was completed
+	function jsonpComplete(requestSettings, callbackContext) {
+		// Process result
+		if ( requestSettings.complete ) {
+			requestSettings.complete.call( callbackContext, {} , status );
+		}
+
+		// The request was completed
+		if ( requestSettings.global ) {
+			trigger( "ajaxComplete", [{}, requestSettings] );
+		}
+
+		// Handle the global AJAX counter
+		if ( requestSettings.global && ! --$.active ) {
+			$.event.trigger( "ajaxStop" );
+		}
+	}
+
+
+	// The core $.ajax replacement.
+	function handleAjax( url, origSettings ) {
+		var mockRequest, requestSettings, mockHandler;
+
+		// If url is an object, simulate pre-1.5 signature
+		if ( typeof url === "object" ) {
+			origSettings = url;
+			url = undefined;
+		} else {
+			// work around to support 1.5 signature
+			origSettings.url = url;
+		}
+
+		// Extend the original settings for the request
+		requestSettings = $.extend(true, {}, $.ajaxSettings, origSettings);
+
+		// Iterate over our mock handlers (in registration order) until we find
+		// one that is willing to intercept the request
+		for(var k = 0; k < mockHandlers.length; k++) {
+			if ( !mockHandlers[k] ) {
+				continue;
+			}
+
+			mockHandler = getMockForRequest( mockHandlers[k], requestSettings );
+			if(!mockHandler) {
+				// No valid mock found for this request
+				continue;
+			}
+
+			mockedAjaxCalls.push(requestSettings);
+
+			// If logging is enabled, log the mock to the console
+			$.mockjaxSettings.log( mockHandler, requestSettings );
+
+
+			if ( requestSettings.dataType === "jsonp" ) {
+				if ((mockRequest = processJsonpMock( requestSettings, mockHandler, origSettings ))) {
+					// This mock will handle the JSONP request
+					return mockRequest;
+				}
+			}
+
+
+			// Removed to fix #54 - keep the mocking data object intact
+			//mockHandler.data = requestSettings.data;
+
+			mockHandler.cache = requestSettings.cache;
+			mockHandler.timeout = requestSettings.timeout;
+			mockHandler.global = requestSettings.global;
+
+			copyUrlParameters(mockHandler, origSettings);
+
+			(function(mockHandler, requestSettings, origSettings, origHandler) {
+				mockRequest = _ajax.call($, $.extend(true, {}, origSettings, {
+					// Mock the XHR object
+					xhr: function() { return xhr( mockHandler, requestSettings, origSettings, origHandler ); }
+				}));
+			})(mockHandler, requestSettings, origSettings, mockHandlers[k]);
+
+			return mockRequest;
+		}
+
+		// We don't have a mock request
+		if($.mockjaxSettings.throwUnmocked === true) {
+			throw('AJAX not mocked: ' + origSettings.url);
+		}
+		else { // trigger a normal request
+			return _ajax.apply($, [origSettings]);
+		}
+	}
+
+	/**
+	* Copies URL parameter values if they were captured by a regular expression
+	* @param {Object} mockHandler
+	* @param {Object} origSettings
+	*/
+	function copyUrlParameters(mockHandler, origSettings) {
+		//parameters aren't captured if the URL isn't a RegExp
+		if (!(mockHandler.url instanceof RegExp)) {
+			return;
+		}
+		//if no URL params were defined on the handler, don't attempt a capture
+		if (!mockHandler.hasOwnProperty('urlParams')) {
+			return;
+		}
+		var captures = mockHandler.url.exec(origSettings.url);
+		//the whole RegExp match is always the first value in the capture results
+		if (captures.length === 1) {
+			return;
+		}
+		captures.shift();
+		//use handler params as keys and capture resuts as values
+		var i = 0,
+		capturesLength = captures.length,
+		paramsLength = mockHandler.urlParams.length,
+		//in case the number of params specified is less than actual captures
+		maxIterations = Math.min(capturesLength, paramsLength),
+		paramValues = {};
+		for (i; i < maxIterations; i++) {
+			var key = mockHandler.urlParams[i];
+			paramValues[key] = captures[i];
+		}
+		origSettings.urlParams = paramValues;
+	}
+
+
+	// Public
+
+	$.extend({
+		ajax: handleAjax
+	});
+
+	$.mockjaxSettings = {
+		//url:        null,
+		//type:       'GET',
+		log:          function( mockHandler, requestSettings ) {
+			if ( mockHandler.logging === false ||
+				 ( typeof mockHandler.logging === 'undefined' && $.mockjaxSettings.logging === false ) ) {
+				return;
+			}
+			if ( window.console && console.log ) {
+				var message = 'MOCK ' + requestSettings.type.toUpperCase() + ': ' + requestSettings.url;
+				var request = $.extend({}, requestSettings);
+
+				if (typeof console.log === 'function') {
+					console.log(message, request);
+				} else {
+					try {
+						console.log( message + ' ' + JSON.stringify(request) );
+					} catch (e) {
+						console.log(message);
+					}
+				}
+			}
+		},
+		logging:       true,
+		status:        200,
+		statusText:    "OK",
+		responseTime:  500,
+		isTimeout:     false,
+		throwUnmocked: false,
+		contentType:   'text/plain',
+		response:      '',
+		responseText:  '',
+		responseXML:   '',
+		proxy:         '',
+		proxyType:     'GET',
+
+		lastModified:  null,
+		etag:          '',
+		headers: {
+			etag: 'IJF@H#@923uf8023hFO@I#H#',
+			'content-type' : 'text/plain'
+		}
+	};
+
+	$.mockjax = function(settings) {
+		var i = mockHandlers.length;
+		mockHandlers[i] = settings;
+		return i;
+	};
+	$.mockjaxClear = function(i) {
+		if ( arguments.length == 1 ) {
+			mockHandlers[i] = null;
+		} else {
+			mockHandlers = [];
+		}
+		mockedAjaxCalls = [];
+	};
+	$.mockjax.handler = function(i) {
+		if ( arguments.length == 1 ) {
+			return mockHandlers[i];
+		}
+	};
+	$.mockjax.mockedAjaxCalls = function() {
+		return mockedAjaxCalls;
+	};
+})(jQuery);

--- a/oabutton/static/test/resources/qunit.css
+++ b/oabutton/static/test/resources/qunit.css
@@ -1,0 +1,244 @@
+/**
+ * QUnit v1.12.0 - A JavaScript Unit Testing Framework
+ *
+ * http://qunitjs.com
+ *
+ * Copyright 2012 jQuery Foundation and other contributors
+ * Released under the MIT license.
+ * http://jquery.org/license
+ */
+
+/** Font Family and Sizes */
+
+#qunit-tests, #qunit-header, #qunit-banner, #qunit-testrunner-toolbar, #qunit-userAgent, #qunit-testresult {
+	font-family: "Helvetica Neue Light", "HelveticaNeue-Light", "Helvetica Neue", Calibri, Helvetica, Arial, sans-serif;
+}
+
+#qunit-testrunner-toolbar, #qunit-userAgent, #qunit-testresult, #qunit-tests li { font-size: small; }
+#qunit-tests { font-size: smaller; }
+
+
+/** Resets */
+
+#qunit-tests, #qunit-header, #qunit-banner, #qunit-userAgent, #qunit-testresult, #qunit-modulefilter {
+	margin: 0;
+	padding: 0;
+}
+
+
+/** Header */
+
+#qunit-header {
+	padding: 0.5em 0 0.5em 1em;
+
+	color: #8699a4;
+	background-color: #0d3349;
+
+	font-size: 1.5em;
+	line-height: 1em;
+	font-weight: normal;
+
+	border-radius: 5px 5px 0 0;
+	-moz-border-radius: 5px 5px 0 0;
+	-webkit-border-top-right-radius: 5px;
+	-webkit-border-top-left-radius: 5px;
+}
+
+#qunit-header a {
+	text-decoration: none;
+	color: #c2ccd1;
+}
+
+#qunit-header a:hover,
+#qunit-header a:focus {
+	color: #fff;
+}
+
+#qunit-testrunner-toolbar label {
+	display: inline-block;
+	padding: 0 .5em 0 .1em;
+}
+
+#qunit-banner {
+	height: 5px;
+}
+
+#qunit-testrunner-toolbar {
+	padding: 0.5em 0 0.5em 2em;
+	color: #5E740B;
+	background-color: #eee;
+	overflow: hidden;
+}
+
+#qunit-userAgent {
+	padding: 0.5em 0 0.5em 2.5em;
+	background-color: #2b81af;
+	color: #fff;
+	text-shadow: rgba(0, 0, 0, 0.5) 2px 2px 1px;
+}
+
+#qunit-modulefilter-container {
+	float: right;
+}
+
+/** Tests: Pass/Fail */
+
+#qunit-tests {
+	list-style-position: inside;
+}
+
+#qunit-tests li {
+	padding: 0.4em 0.5em 0.4em 2.5em;
+	border-bottom: 1px solid #fff;
+	list-style-position: inside;
+}
+
+#qunit-tests.hidepass li.pass, #qunit-tests.hidepass li.running  {
+	display: none;
+}
+
+#qunit-tests li strong {
+	cursor: pointer;
+}
+
+#qunit-tests li a {
+	padding: 0.5em;
+	color: #c2ccd1;
+	text-decoration: none;
+}
+#qunit-tests li a:hover,
+#qunit-tests li a:focus {
+	color: #000;
+}
+
+#qunit-tests li .runtime {
+	float: right;
+	font-size: smaller;
+}
+
+.qunit-assert-list {
+	margin-top: 0.5em;
+	padding: 0.5em;
+
+	background-color: #fff;
+
+	border-radius: 5px;
+	-moz-border-radius: 5px;
+	-webkit-border-radius: 5px;
+}
+
+.qunit-collapsed {
+	display: none;
+}
+
+#qunit-tests table {
+	border-collapse: collapse;
+	margin-top: .2em;
+}
+
+#qunit-tests th {
+	text-align: right;
+	vertical-align: top;
+	padding: 0 .5em 0 0;
+}
+
+#qunit-tests td {
+	vertical-align: top;
+}
+
+#qunit-tests pre {
+	margin: 0;
+	white-space: pre-wrap;
+	word-wrap: break-word;
+}
+
+#qunit-tests del {
+	background-color: #e0f2be;
+	color: #374e0c;
+	text-decoration: none;
+}
+
+#qunit-tests ins {
+	background-color: #ffcaca;
+	color: #500;
+	text-decoration: none;
+}
+
+/*** Test Counts */
+
+#qunit-tests b.counts                       { color: black; }
+#qunit-tests b.passed                       { color: #5E740B; }
+#qunit-tests b.failed                       { color: #710909; }
+
+#qunit-tests li li {
+	padding: 5px;
+	background-color: #fff;
+	border-bottom: none;
+	list-style-position: inside;
+}
+
+/*** Passing Styles */
+
+#qunit-tests li li.pass {
+	color: #3c510c;
+	background-color: #fff;
+	border-left: 10px solid #C6E746;
+}
+
+#qunit-tests .pass                          { color: #528CE0; background-color: #D2E0E6; }
+#qunit-tests .pass .test-name               { color: #366097; }
+
+#qunit-tests .pass .test-actual,
+#qunit-tests .pass .test-expected           { color: #999999; }
+
+#qunit-banner.qunit-pass                    { background-color: #C6E746; }
+
+/*** Failing Styles */
+
+#qunit-tests li li.fail {
+	color: #710909;
+	background-color: #fff;
+	border-left: 10px solid #EE5757;
+	white-space: pre;
+}
+
+#qunit-tests > li:last-child {
+	border-radius: 0 0 5px 5px;
+	-moz-border-radius: 0 0 5px 5px;
+	-webkit-border-bottom-right-radius: 5px;
+	-webkit-border-bottom-left-radius: 5px;
+}
+
+#qunit-tests .fail                          { color: #000000; background-color: #EE5757; }
+#qunit-tests .fail .test-name,
+#qunit-tests .fail .module-name             { color: #000000; }
+
+#qunit-tests .fail .test-actual             { color: #EE5757; }
+#qunit-tests .fail .test-expected           { color: green;   }
+
+#qunit-banner.qunit-fail                    { background-color: #EE5757; }
+
+
+/** Result */
+
+#qunit-testresult {
+	padding: 0.5em 0.5em 0.5em 2.5em;
+
+	color: #2b81af;
+	background-color: #D2E0E6;
+
+	border-bottom: 1px solid white;
+}
+#qunit-testresult .module-name {
+	font-weight: bold;
+}
+
+/** Fixture */
+
+#qunit-fixture {
+	position: absolute;
+	top: -10000px;
+	left: -10000px;
+	width: 1000px;
+	height: 1000px;
+}

--- a/oabutton/static/test/resources/qunit.js
+++ b/oabutton/static/test/resources/qunit.js
@@ -1,0 +1,2212 @@
+/**
+ * QUnit v1.12.0 - A JavaScript Unit Testing Framework
+ *
+ * http://qunitjs.com
+ *
+ * Copyright 2013 jQuery Foundation and other contributors
+ * Released under the MIT license.
+ * https://jquery.org/license/
+ */
+
+(function( window ) {
+
+var QUnit,
+	assert,
+	config,
+	onErrorFnPrev,
+	testId = 0,
+	fileName = (sourceFromStacktrace( 0 ) || "" ).replace(/(:\d+)+\)?/, "").replace(/.+\//, ""),
+	toString = Object.prototype.toString,
+	hasOwn = Object.prototype.hasOwnProperty,
+	// Keep a local reference to Date (GH-283)
+	Date = window.Date,
+	setTimeout = window.setTimeout,
+	defined = {
+		setTimeout: typeof window.setTimeout !== "undefined",
+		sessionStorage: (function() {
+			var x = "qunit-test-string";
+			try {
+				sessionStorage.setItem( x, x );
+				sessionStorage.removeItem( x );
+				return true;
+			} catch( e ) {
+				return false;
+			}
+		}())
+	},
+	/**
+	 * Provides a normalized error string, correcting an issue
+	 * with IE 7 (and prior) where Error.prototype.toString is
+	 * not properly implemented
+	 *
+	 * Based on http://es5.github.com/#x15.11.4.4
+	 *
+	 * @param {String|Error} error
+	 * @return {String} error message
+	 */
+	errorString = function( error ) {
+		var name, message,
+			errorString = error.toString();
+		if ( errorString.substring( 0, 7 ) === "[object" ) {
+			name = error.name ? error.name.toString() : "Error";
+			message = error.message ? error.message.toString() : "";
+			if ( name && message ) {
+				return name + ": " + message;
+			} else if ( name ) {
+				return name;
+			} else if ( message ) {
+				return message;
+			} else {
+				return "Error";
+			}
+		} else {
+			return errorString;
+		}
+	},
+	/**
+	 * Makes a clone of an object using only Array or Object as base,
+	 * and copies over the own enumerable properties.
+	 *
+	 * @param {Object} obj
+	 * @return {Object} New object with only the own properties (recursively).
+	 */
+	objectValues = function( obj ) {
+		// Grunt 0.3.x uses an older version of jshint that still has jshint/jshint#392.
+		/*jshint newcap: false */
+		var key, val,
+			vals = QUnit.is( "array", obj ) ? [] : {};
+		for ( key in obj ) {
+			if ( hasOwn.call( obj, key ) ) {
+				val = obj[key];
+				vals[key] = val === Object(val) ? objectValues(val) : val;
+			}
+		}
+		return vals;
+	};
+
+function Test( settings ) {
+	extend( this, settings );
+	this.assertions = [];
+	this.testNumber = ++Test.count;
+}
+
+Test.count = 0;
+
+Test.prototype = {
+	init: function() {
+		var a, b, li,
+			tests = id( "qunit-tests" );
+
+		if ( tests ) {
+			b = document.createElement( "strong" );
+			b.innerHTML = this.nameHtml;
+
+			// `a` initialized at top of scope
+			a = document.createElement( "a" );
+			a.innerHTML = "Rerun";
+			a.href = QUnit.url({ testNumber: this.testNumber });
+
+			li = document.createElement( "li" );
+			li.appendChild( b );
+			li.appendChild( a );
+			li.className = "running";
+			li.id = this.id = "qunit-test-output" + testId++;
+
+			tests.appendChild( li );
+		}
+	},
+	setup: function() {
+		if (
+			// Emit moduleStart when we're switching from one module to another
+			this.module !== config.previousModule ||
+				// They could be equal (both undefined) but if the previousModule property doesn't
+				// yet exist it means this is the first test in a suite that isn't wrapped in a
+				// module, in which case we'll just emit a moduleStart event for 'undefined'.
+				// Without this, reporters can get testStart before moduleStart  which is a problem.
+				!hasOwn.call( config, "previousModule" )
+		) {
+			if ( hasOwn.call( config, "previousModule" ) ) {
+				runLoggingCallbacks( "moduleDone", QUnit, {
+					name: config.previousModule,
+					failed: config.moduleStats.bad,
+					passed: config.moduleStats.all - config.moduleStats.bad,
+					total: config.moduleStats.all
+				});
+			}
+			config.previousModule = this.module;
+			config.moduleStats = { all: 0, bad: 0 };
+			runLoggingCallbacks( "moduleStart", QUnit, {
+				name: this.module
+			});
+		}
+
+		config.current = this;
+
+		this.testEnvironment = extend({
+			setup: function() {},
+			teardown: function() {}
+		}, this.moduleTestEnvironment );
+
+		this.started = +new Date();
+		runLoggingCallbacks( "testStart", QUnit, {
+			name: this.testName,
+			module: this.module
+		});
+
+		/*jshint camelcase:false */
+
+
+		/**
+		 * Expose the current test environment.
+		 *
+		 * @deprecated since 1.12.0: Use QUnit.config.current.testEnvironment instead.
+		 */
+		QUnit.current_testEnvironment = this.testEnvironment;
+
+		/*jshint camelcase:true */
+
+		if ( !config.pollution ) {
+			saveGlobal();
+		}
+		if ( config.notrycatch ) {
+			this.testEnvironment.setup.call( this.testEnvironment, QUnit.assert );
+			return;
+		}
+		try {
+			this.testEnvironment.setup.call( this.testEnvironment, QUnit.assert );
+		} catch( e ) {
+			QUnit.pushFailure( "Setup failed on " + this.testName + ": " + ( e.message || e ), extractStacktrace( e, 1 ) );
+		}
+	},
+	run: function() {
+		config.current = this;
+
+		var running = id( "qunit-testresult" );
+
+		if ( running ) {
+			running.innerHTML = "Running: <br/>" + this.nameHtml;
+		}
+
+		if ( this.async ) {
+			QUnit.stop();
+		}
+
+		this.callbackStarted = +new Date();
+
+		if ( config.notrycatch ) {
+			this.callback.call( this.testEnvironment, QUnit.assert );
+			this.callbackRuntime = +new Date() - this.callbackStarted;
+			return;
+		}
+
+		try {
+			this.callback.call( this.testEnvironment, QUnit.assert );
+			this.callbackRuntime = +new Date() - this.callbackStarted;
+		} catch( e ) {
+			this.callbackRuntime = +new Date() - this.callbackStarted;
+
+			QUnit.pushFailure( "Died on test #" + (this.assertions.length + 1) + " " + this.stack + ": " + ( e.message || e ), extractStacktrace( e, 0 ) );
+			// else next test will carry the responsibility
+			saveGlobal();
+
+			// Restart the tests if they're blocking
+			if ( config.blocking ) {
+				QUnit.start();
+			}
+		}
+	},
+	teardown: function() {
+		config.current = this;
+		if ( config.notrycatch ) {
+			if ( typeof this.callbackRuntime === "undefined" ) {
+				this.callbackRuntime = +new Date() - this.callbackStarted;
+			}
+			this.testEnvironment.teardown.call( this.testEnvironment, QUnit.assert );
+			return;
+		} else {
+			try {
+				this.testEnvironment.teardown.call( this.testEnvironment, QUnit.assert );
+			} catch( e ) {
+				QUnit.pushFailure( "Teardown failed on " + this.testName + ": " + ( e.message || e ), extractStacktrace( e, 1 ) );
+			}
+		}
+		checkPollution();
+	},
+	finish: function() {
+		config.current = this;
+		if ( config.requireExpects && this.expected === null ) {
+			QUnit.pushFailure( "Expected number of assertions to be defined, but expect() was not called.", this.stack );
+		} else if ( this.expected !== null && this.expected !== this.assertions.length ) {
+			QUnit.pushFailure( "Expected " + this.expected + " assertions, but " + this.assertions.length + " were run", this.stack );
+		} else if ( this.expected === null && !this.assertions.length ) {
+			QUnit.pushFailure( "Expected at least one assertion, but none were run - call expect(0) to accept zero assertions.", this.stack );
+		}
+
+		var i, assertion, a, b, time, li, ol,
+			test = this,
+			good = 0,
+			bad = 0,
+			tests = id( "qunit-tests" );
+
+		this.runtime = +new Date() - this.started;
+		config.stats.all += this.assertions.length;
+		config.moduleStats.all += this.assertions.length;
+
+		if ( tests ) {
+			ol = document.createElement( "ol" );
+			ol.className = "qunit-assert-list";
+
+			for ( i = 0; i < this.assertions.length; i++ ) {
+				assertion = this.assertions[i];
+
+				li = document.createElement( "li" );
+				li.className = assertion.result ? "pass" : "fail";
+				li.innerHTML = assertion.message || ( assertion.result ? "okay" : "failed" );
+				ol.appendChild( li );
+
+				if ( assertion.result ) {
+					good++;
+				} else {
+					bad++;
+					config.stats.bad++;
+					config.moduleStats.bad++;
+				}
+			}
+
+			// store result when possible
+			if ( QUnit.config.reorder && defined.sessionStorage ) {
+				if ( bad ) {
+					sessionStorage.setItem( "qunit-test-" + this.module + "-" + this.testName, bad );
+				} else {
+					sessionStorage.removeItem( "qunit-test-" + this.module + "-" + this.testName );
+				}
+			}
+
+			if ( bad === 0 ) {
+				addClass( ol, "qunit-collapsed" );
+			}
+
+			// `b` initialized at top of scope
+			b = document.createElement( "strong" );
+			b.innerHTML = this.nameHtml + " <b class='counts'>(<b class='failed'>" + bad + "</b>, <b class='passed'>" + good + "</b>, " + this.assertions.length + ")</b>";
+
+			addEvent(b, "click", function() {
+				var next = b.parentNode.lastChild,
+					collapsed = hasClass( next, "qunit-collapsed" );
+				( collapsed ? removeClass : addClass )( next, "qunit-collapsed" );
+			});
+
+			addEvent(b, "dblclick", function( e ) {
+				var target = e && e.target ? e.target : window.event.srcElement;
+				if ( target.nodeName.toLowerCase() === "span" || target.nodeName.toLowerCase() === "b" ) {
+					target = target.parentNode;
+				}
+				if ( window.location && target.nodeName.toLowerCase() === "strong" ) {
+					window.location = QUnit.url({ testNumber: test.testNumber });
+				}
+			});
+
+			// `time` initialized at top of scope
+			time = document.createElement( "span" );
+			time.className = "runtime";
+			time.innerHTML = this.runtime + " ms";
+
+			// `li` initialized at top of scope
+			li = id( this.id );
+			li.className = bad ? "fail" : "pass";
+			li.removeChild( li.firstChild );
+			a = li.firstChild;
+			li.appendChild( b );
+			li.appendChild( a );
+			li.appendChild( time );
+			li.appendChild( ol );
+
+		} else {
+			for ( i = 0; i < this.assertions.length; i++ ) {
+				if ( !this.assertions[i].result ) {
+					bad++;
+					config.stats.bad++;
+					config.moduleStats.bad++;
+				}
+			}
+		}
+
+		runLoggingCallbacks( "testDone", QUnit, {
+			name: this.testName,
+			module: this.module,
+			failed: bad,
+			passed: this.assertions.length - bad,
+			total: this.assertions.length,
+			duration: this.runtime
+		});
+
+		QUnit.reset();
+
+		config.current = undefined;
+	},
+
+	queue: function() {
+		var bad,
+			test = this;
+
+		synchronize(function() {
+			test.init();
+		});
+		function run() {
+			// each of these can by async
+			synchronize(function() {
+				test.setup();
+			});
+			synchronize(function() {
+				test.run();
+			});
+			synchronize(function() {
+				test.teardown();
+			});
+			synchronize(function() {
+				test.finish();
+			});
+		}
+
+		// `bad` initialized at top of scope
+		// defer when previous test run passed, if storage is available
+		bad = QUnit.config.reorder && defined.sessionStorage &&
+						+sessionStorage.getItem( "qunit-test-" + this.module + "-" + this.testName );
+
+		if ( bad ) {
+			run();
+		} else {
+			synchronize( run, true );
+		}
+	}
+};
+
+// Root QUnit object.
+// `QUnit` initialized at top of scope
+QUnit = {
+
+	// call on start of module test to prepend name to all tests
+	module: function( name, testEnvironment ) {
+		config.currentModule = name;
+		config.currentModuleTestEnvironment = testEnvironment;
+		config.modules[name] = true;
+	},
+
+	asyncTest: function( testName, expected, callback ) {
+		if ( arguments.length === 2 ) {
+			callback = expected;
+			expected = null;
+		}
+
+		QUnit.test( testName, expected, callback, true );
+	},
+
+	test: function( testName, expected, callback, async ) {
+		var test,
+			nameHtml = "<span class='test-name'>" + escapeText( testName ) + "</span>";
+
+		if ( arguments.length === 2 ) {
+			callback = expected;
+			expected = null;
+		}
+
+		if ( config.currentModule ) {
+			nameHtml = "<span class='module-name'>" + escapeText( config.currentModule ) + "</span>: " + nameHtml;
+		}
+
+		test = new Test({
+			nameHtml: nameHtml,
+			testName: testName,
+			expected: expected,
+			async: async,
+			callback: callback,
+			module: config.currentModule,
+			moduleTestEnvironment: config.currentModuleTestEnvironment,
+			stack: sourceFromStacktrace( 2 )
+		});
+
+		if ( !validTest( test ) ) {
+			return;
+		}
+
+		test.queue();
+	},
+
+	// Specify the number of expected assertions to guarantee that failed test (no assertions are run at all) don't slip through.
+	expect: function( asserts ) {
+		if (arguments.length === 1) {
+			config.current.expected = asserts;
+		} else {
+			return config.current.expected;
+		}
+	},
+
+	start: function( count ) {
+		// QUnit hasn't been initialized yet.
+		// Note: RequireJS (et al) may delay onLoad
+		if ( config.semaphore === undefined ) {
+			QUnit.begin(function() {
+				// This is triggered at the top of QUnit.load, push start() to the event loop, to allow QUnit.load to finish first
+				setTimeout(function() {
+					QUnit.start( count );
+				});
+			});
+			return;
+		}
+
+		config.semaphore -= count || 1;
+		// don't start until equal number of stop-calls
+		if ( config.semaphore > 0 ) {
+			return;
+		}
+		// ignore if start is called more often then stop
+		if ( config.semaphore < 0 ) {
+			config.semaphore = 0;
+			QUnit.pushFailure( "Called start() while already started (QUnit.config.semaphore was 0 already)", null, sourceFromStacktrace(2) );
+			return;
+		}
+		// A slight delay, to avoid any current callbacks
+		if ( defined.setTimeout ) {
+			setTimeout(function() {
+				if ( config.semaphore > 0 ) {
+					return;
+				}
+				if ( config.timeout ) {
+					clearTimeout( config.timeout );
+				}
+
+				config.blocking = false;
+				process( true );
+			}, 13);
+		} else {
+			config.blocking = false;
+			process( true );
+		}
+	},
+
+	stop: function( count ) {
+		config.semaphore += count || 1;
+		config.blocking = true;
+
+		if ( config.testTimeout && defined.setTimeout ) {
+			clearTimeout( config.timeout );
+			config.timeout = setTimeout(function() {
+				QUnit.ok( false, "Test timed out" );
+				config.semaphore = 1;
+				QUnit.start();
+			}, config.testTimeout );
+		}
+	}
+};
+
+// `assert` initialized at top of scope
+// Assert helpers
+// All of these must either call QUnit.push() or manually do:
+// - runLoggingCallbacks( "log", .. );
+// - config.current.assertions.push({ .. });
+// We attach it to the QUnit object *after* we expose the public API,
+// otherwise `assert` will become a global variable in browsers (#341).
+assert = {
+	/**
+	 * Asserts rough true-ish result.
+	 * @name ok
+	 * @function
+	 * @example ok( "asdfasdf".length > 5, "There must be at least 5 chars" );
+	 */
+	ok: function( result, msg ) {
+		if ( !config.current ) {
+			throw new Error( "ok() assertion outside test context, was " + sourceFromStacktrace(2) );
+		}
+		result = !!result;
+		msg = msg || (result ? "okay" : "failed" );
+
+		var source,
+			details = {
+				module: config.current.module,
+				name: config.current.testName,
+				result: result,
+				message: msg
+			};
+
+		msg = "<span class='test-message'>" + escapeText( msg ) + "</span>";
+
+		if ( !result ) {
+			source = sourceFromStacktrace( 2 );
+			if ( source ) {
+				details.source = source;
+				msg += "<table><tr class='test-source'><th>Source: </th><td><pre>" + escapeText( source ) + "</pre></td></tr></table>";
+			}
+		}
+		runLoggingCallbacks( "log", QUnit, details );
+		config.current.assertions.push({
+			result: result,
+			message: msg
+		});
+	},
+
+	/**
+	 * Assert that the first two arguments are equal, with an optional message.
+	 * Prints out both actual and expected values.
+	 * @name equal
+	 * @function
+	 * @example equal( format( "Received {0} bytes.", 2), "Received 2 bytes.", "format() replaces {0} with next argument" );
+	 */
+	equal: function( actual, expected, message ) {
+		/*jshint eqeqeq:false */
+		QUnit.push( expected == actual, actual, expected, message );
+	},
+
+	/**
+	 * @name notEqual
+	 * @function
+	 */
+	notEqual: function( actual, expected, message ) {
+		/*jshint eqeqeq:false */
+		QUnit.push( expected != actual, actual, expected, message );
+	},
+
+	/**
+	 * @name propEqual
+	 * @function
+	 */
+	propEqual: function( actual, expected, message ) {
+		actual = objectValues(actual);
+		expected = objectValues(expected);
+		QUnit.push( QUnit.equiv(actual, expected), actual, expected, message );
+	},
+
+	/**
+	 * @name notPropEqual
+	 * @function
+	 */
+	notPropEqual: function( actual, expected, message ) {
+		actual = objectValues(actual);
+		expected = objectValues(expected);
+		QUnit.push( !QUnit.equiv(actual, expected), actual, expected, message );
+	},
+
+	/**
+	 * @name deepEqual
+	 * @function
+	 */
+	deepEqual: function( actual, expected, message ) {
+		QUnit.push( QUnit.equiv(actual, expected), actual, expected, message );
+	},
+
+	/**
+	 * @name notDeepEqual
+	 * @function
+	 */
+	notDeepEqual: function( actual, expected, message ) {
+		QUnit.push( !QUnit.equiv(actual, expected), actual, expected, message );
+	},
+
+	/**
+	 * @name strictEqual
+	 * @function
+	 */
+	strictEqual: function( actual, expected, message ) {
+		QUnit.push( expected === actual, actual, expected, message );
+	},
+
+	/**
+	 * @name notStrictEqual
+	 * @function
+	 */
+	notStrictEqual: function( actual, expected, message ) {
+		QUnit.push( expected !== actual, actual, expected, message );
+	},
+
+	"throws": function( block, expected, message ) {
+		var actual,
+			expectedOutput = expected,
+			ok = false;
+
+		// 'expected' is optional
+		if ( typeof expected === "string" ) {
+			message = expected;
+			expected = null;
+		}
+
+		config.current.ignoreGlobalErrors = true;
+		try {
+			block.call( config.current.testEnvironment );
+		} catch (e) {
+			actual = e;
+		}
+		config.current.ignoreGlobalErrors = false;
+
+		if ( actual ) {
+			// we don't want to validate thrown error
+			if ( !expected ) {
+				ok = true;
+				expectedOutput = null;
+			// expected is a regexp
+			} else if ( QUnit.objectType( expected ) === "regexp" ) {
+				ok = expected.test( errorString( actual ) );
+			// expected is a constructor
+			} else if ( actual instanceof expected ) {
+				ok = true;
+			// expected is a validation function which returns true is validation passed
+			} else if ( expected.call( {}, actual ) === true ) {
+				expectedOutput = null;
+				ok = true;
+			}
+
+			QUnit.push( ok, actual, expectedOutput, message );
+		} else {
+			QUnit.pushFailure( message, null, "No exception was thrown." );
+		}
+	}
+};
+
+/**
+ * @deprecated since 1.8.0
+ * Kept assertion helpers in root for backwards compatibility.
+ */
+extend( QUnit, assert );
+
+/**
+ * @deprecated since 1.9.0
+ * Kept root "raises()" for backwards compatibility.
+ * (Note that we don't introduce assert.raises).
+ */
+QUnit.raises = assert[ "throws" ];
+
+/**
+ * @deprecated since 1.0.0, replaced with error pushes since 1.3.0
+ * Kept to avoid TypeErrors for undefined methods.
+ */
+QUnit.equals = function() {
+	QUnit.push( false, false, false, "QUnit.equals has been deprecated since 2009 (e88049a0), use QUnit.equal instead" );
+};
+QUnit.same = function() {
+	QUnit.push( false, false, false, "QUnit.same has been deprecated since 2009 (e88049a0), use QUnit.deepEqual instead" );
+};
+
+// We want access to the constructor's prototype
+(function() {
+	function F() {}
+	F.prototype = QUnit;
+	QUnit = new F();
+	// Make F QUnit's constructor so that we can add to the prototype later
+	QUnit.constructor = F;
+}());
+
+/**
+ * Config object: Maintain internal state
+ * Later exposed as QUnit.config
+ * `config` initialized at top of scope
+ */
+config = {
+	// The queue of tests to run
+	queue: [],
+
+	// block until document ready
+	blocking: true,
+
+	// when enabled, show only failing tests
+	// gets persisted through sessionStorage and can be changed in UI via checkbox
+	hidepassed: false,
+
+	// by default, run previously failed tests first
+	// very useful in combination with "Hide passed tests" checked
+	reorder: true,
+
+	// by default, modify document.title when suite is done
+	altertitle: true,
+
+	// when enabled, all tests must call expect()
+	requireExpects: false,
+
+	// add checkboxes that are persisted in the query-string
+	// when enabled, the id is set to `true` as a `QUnit.config` property
+	urlConfig: [
+		{
+			id: "noglobals",
+			label: "Check for Globals",
+			tooltip: "Enabling this will test if any test introduces new properties on the `window` object. Stored as query-strings."
+		},
+		{
+			id: "notrycatch",
+			label: "No try-catch",
+			tooltip: "Enabling this will run tests outside of a try-catch block. Makes debugging exceptions in IE reasonable. Stored as query-strings."
+		}
+	],
+
+	// Set of all modules.
+	modules: {},
+
+	// logging callback queues
+	begin: [],
+	done: [],
+	log: [],
+	testStart: [],
+	testDone: [],
+	moduleStart: [],
+	moduleDone: []
+};
+
+// Export global variables, unless an 'exports' object exists,
+// in that case we assume we're in CommonJS (dealt with on the bottom of the script)
+if ( typeof exports === "undefined" ) {
+	extend( window, QUnit.constructor.prototype );
+
+	// Expose QUnit object
+	window.QUnit = QUnit;
+}
+
+// Initialize more QUnit.config and QUnit.urlParams
+(function() {
+	var i,
+		location = window.location || { search: "", protocol: "file:" },
+		params = location.search.slice( 1 ).split( "&" ),
+		length = params.length,
+		urlParams = {},
+		current;
+
+	if ( params[ 0 ] ) {
+		for ( i = 0; i < length; i++ ) {
+			current = params[ i ].split( "=" );
+			current[ 0 ] = decodeURIComponent( current[ 0 ] );
+			// allow just a key to turn on a flag, e.g., test.html?noglobals
+			current[ 1 ] = current[ 1 ] ? decodeURIComponent( current[ 1 ] ) : true;
+			urlParams[ current[ 0 ] ] = current[ 1 ];
+		}
+	}
+
+	QUnit.urlParams = urlParams;
+
+	// String search anywhere in moduleName+testName
+	config.filter = urlParams.filter;
+
+	// Exact match of the module name
+	config.module = urlParams.module;
+
+	config.testNumber = parseInt( urlParams.testNumber, 10 ) || null;
+
+	// Figure out if we're running the tests from a server or not
+	QUnit.isLocal = location.protocol === "file:";
+}());
+
+// Extend QUnit object,
+// these after set here because they should not be exposed as global functions
+extend( QUnit, {
+	assert: assert,
+
+	config: config,
+
+	// Initialize the configuration options
+	init: function() {
+		extend( config, {
+			stats: { all: 0, bad: 0 },
+			moduleStats: { all: 0, bad: 0 },
+			started: +new Date(),
+			updateRate: 1000,
+			blocking: false,
+			autostart: true,
+			autorun: false,
+			filter: "",
+			queue: [],
+			semaphore: 1
+		});
+
+		var tests, banner, result,
+			qunit = id( "qunit" );
+
+		if ( qunit ) {
+			qunit.innerHTML =
+				"<h1 id='qunit-header'>" + escapeText( document.title ) + "</h1>" +
+				"<h2 id='qunit-banner'></h2>" +
+				"<div id='qunit-testrunner-toolbar'></div>" +
+				"<h2 id='qunit-userAgent'></h2>" +
+				"<ol id='qunit-tests'></ol>";
+		}
+
+		tests = id( "qunit-tests" );
+		banner = id( "qunit-banner" );
+		result = id( "qunit-testresult" );
+
+		if ( tests ) {
+			tests.innerHTML = "";
+		}
+
+		if ( banner ) {
+			banner.className = "";
+		}
+
+		if ( result ) {
+			result.parentNode.removeChild( result );
+		}
+
+		if ( tests ) {
+			result = document.createElement( "p" );
+			result.id = "qunit-testresult";
+			result.className = "result";
+			tests.parentNode.insertBefore( result, tests );
+			result.innerHTML = "Running...<br/>&nbsp;";
+		}
+	},
+
+	// Resets the test setup. Useful for tests that modify the DOM.
+	/*
+	DEPRECATED: Use multiple tests instead of resetting inside a test.
+	Use testStart or testDone for custom cleanup.
+	This method will throw an error in 2.0, and will be removed in 2.1
+	*/
+	reset: function() {
+		var fixture = id( "qunit-fixture" );
+		if ( fixture ) {
+			fixture.innerHTML = config.fixture;
+		}
+	},
+
+	// Trigger an event on an element.
+	// @example triggerEvent( document.body, "click" );
+	triggerEvent: function( elem, type, event ) {
+		if ( document.createEvent ) {
+			event = document.createEvent( "MouseEvents" );
+			event.initMouseEvent(type, true, true, elem.ownerDocument.defaultView,
+				0, 0, 0, 0, 0, false, false, false, false, 0, null);
+
+			elem.dispatchEvent( event );
+		} else if ( elem.fireEvent ) {
+			elem.fireEvent( "on" + type );
+		}
+	},
+
+	// Safe object type checking
+	is: function( type, obj ) {
+		return QUnit.objectType( obj ) === type;
+	},
+
+	objectType: function( obj ) {
+		if ( typeof obj === "undefined" ) {
+				return "undefined";
+		// consider: typeof null === object
+		}
+		if ( obj === null ) {
+				return "null";
+		}
+
+		var match = toString.call( obj ).match(/^\[object\s(.*)\]$/),
+			type = match && match[1] || "";
+
+		switch ( type ) {
+			case "Number":
+				if ( isNaN(obj) ) {
+					return "nan";
+				}
+				return "number";
+			case "String":
+			case "Boolean":
+			case "Array":
+			case "Date":
+			case "RegExp":
+			case "Function":
+				return type.toLowerCase();
+		}
+		if ( typeof obj === "object" ) {
+			return "object";
+		}
+		return undefined;
+	},
+
+	push: function( result, actual, expected, message ) {
+		if ( !config.current ) {
+			throw new Error( "assertion outside test context, was " + sourceFromStacktrace() );
+		}
+
+		var output, source,
+			details = {
+				module: config.current.module,
+				name: config.current.testName,
+				result: result,
+				message: message,
+				actual: actual,
+				expected: expected
+			};
+
+		message = escapeText( message ) || ( result ? "okay" : "failed" );
+		message = "<span class='test-message'>" + message + "</span>";
+		output = message;
+
+		if ( !result ) {
+			expected = escapeText( QUnit.jsDump.parse(expected) );
+			actual = escapeText( QUnit.jsDump.parse(actual) );
+			output += "<table><tr class='test-expected'><th>Expected: </th><td><pre>" + expected + "</pre></td></tr>";
+
+			if ( actual !== expected ) {
+				output += "<tr class='test-actual'><th>Result: </th><td><pre>" + actual + "</pre></td></tr>";
+				output += "<tr class='test-diff'><th>Diff: </th><td><pre>" + QUnit.diff( expected, actual ) + "</pre></td></tr>";
+			}
+
+			source = sourceFromStacktrace();
+
+			if ( source ) {
+				details.source = source;
+				output += "<tr class='test-source'><th>Source: </th><td><pre>" + escapeText( source ) + "</pre></td></tr>";
+			}
+
+			output += "</table>";
+		}
+
+		runLoggingCallbacks( "log", QUnit, details );
+
+		config.current.assertions.push({
+			result: !!result,
+			message: output
+		});
+	},
+
+	pushFailure: function( message, source, actual ) {
+		if ( !config.current ) {
+			throw new Error( "pushFailure() assertion outside test context, was " + sourceFromStacktrace(2) );
+		}
+
+		var output,
+			details = {
+				module: config.current.module,
+				name: config.current.testName,
+				result: false,
+				message: message
+			};
+
+		message = escapeText( message ) || "error";
+		message = "<span class='test-message'>" + message + "</span>";
+		output = message;
+
+		output += "<table>";
+
+		if ( actual ) {
+			output += "<tr class='test-actual'><th>Result: </th><td><pre>" + escapeText( actual ) + "</pre></td></tr>";
+		}
+
+		if ( source ) {
+			details.source = source;
+			output += "<tr class='test-source'><th>Source: </th><td><pre>" + escapeText( source ) + "</pre></td></tr>";
+		}
+
+		output += "</table>";
+
+		runLoggingCallbacks( "log", QUnit, details );
+
+		config.current.assertions.push({
+			result: false,
+			message: output
+		});
+	},
+
+	url: function( params ) {
+		params = extend( extend( {}, QUnit.urlParams ), params );
+		var key,
+			querystring = "?";
+
+		for ( key in params ) {
+			if ( hasOwn.call( params, key ) ) {
+				querystring += encodeURIComponent( key ) + "=" +
+					encodeURIComponent( params[ key ] ) + "&";
+			}
+		}
+		return window.location.protocol + "//" + window.location.host +
+			window.location.pathname + querystring.slice( 0, -1 );
+	},
+
+	extend: extend,
+	id: id,
+	addEvent: addEvent,
+	addClass: addClass,
+	hasClass: hasClass,
+	removeClass: removeClass
+	// load, equiv, jsDump, diff: Attached later
+});
+
+/**
+ * @deprecated: Created for backwards compatibility with test runner that set the hook function
+ * into QUnit.{hook}, instead of invoking it and passing the hook function.
+ * QUnit.constructor is set to the empty F() above so that we can add to it's prototype here.
+ * Doing this allows us to tell if the following methods have been overwritten on the actual
+ * QUnit object.
+ */
+extend( QUnit.constructor.prototype, {
+
+	// Logging callbacks; all receive a single argument with the listed properties
+	// run test/logs.html for any related changes
+	begin: registerLoggingCallback( "begin" ),
+
+	// done: { failed, passed, total, runtime }
+	done: registerLoggingCallback( "done" ),
+
+	// log: { result, actual, expected, message }
+	log: registerLoggingCallback( "log" ),
+
+	// testStart: { name }
+	testStart: registerLoggingCallback( "testStart" ),
+
+	// testDone: { name, failed, passed, total, duration }
+	testDone: registerLoggingCallback( "testDone" ),
+
+	// moduleStart: { name }
+	moduleStart: registerLoggingCallback( "moduleStart" ),
+
+	// moduleDone: { name, failed, passed, total }
+	moduleDone: registerLoggingCallback( "moduleDone" )
+});
+
+if ( typeof document === "undefined" || document.readyState === "complete" ) {
+	config.autorun = true;
+}
+
+QUnit.load = function() {
+	runLoggingCallbacks( "begin", QUnit, {} );
+
+	// Initialize the config, saving the execution queue
+	var banner, filter, i, label, len, main, ol, toolbar, userAgent, val,
+		urlConfigCheckboxesContainer, urlConfigCheckboxes, moduleFilter,
+		numModules = 0,
+		moduleNames = [],
+		moduleFilterHtml = "",
+		urlConfigHtml = "",
+		oldconfig = extend( {}, config );
+
+	QUnit.init();
+	extend(config, oldconfig);
+
+	config.blocking = false;
+
+	len = config.urlConfig.length;
+
+	for ( i = 0; i < len; i++ ) {
+		val = config.urlConfig[i];
+		if ( typeof val === "string" ) {
+			val = {
+				id: val,
+				label: val,
+				tooltip: "[no tooltip available]"
+			};
+		}
+		config[ val.id ] = QUnit.urlParams[ val.id ];
+		urlConfigHtml += "<input id='qunit-urlconfig-" + escapeText( val.id ) +
+			"' name='" + escapeText( val.id ) +
+			"' type='checkbox'" + ( config[ val.id ] ? " checked='checked'" : "" ) +
+			" title='" + escapeText( val.tooltip ) +
+			"'><label for='qunit-urlconfig-" + escapeText( val.id ) +
+			"' title='" + escapeText( val.tooltip ) + "'>" + val.label + "</label>";
+	}
+	for ( i in config.modules ) {
+		if ( config.modules.hasOwnProperty( i ) ) {
+			moduleNames.push(i);
+		}
+	}
+	numModules = moduleNames.length;
+	moduleNames.sort( function( a, b ) {
+		return a.localeCompare( b );
+	});
+	moduleFilterHtml += "<label for='qunit-modulefilter'>Module: </label><select id='qunit-modulefilter' name='modulefilter'><option value='' " +
+		( config.module === undefined  ? "selected='selected'" : "" ) +
+		">< All Modules ></option>";
+
+
+	for ( i = 0; i < numModules; i++) {
+			moduleFilterHtml += "<option value='" + escapeText( encodeURIComponent(moduleNames[i]) ) + "' " +
+				( config.module === moduleNames[i] ? "selected='selected'" : "" ) +
+				">" + escapeText(moduleNames[i]) + "</option>";
+	}
+	moduleFilterHtml += "</select>";
+
+	// `userAgent` initialized at top of scope
+	userAgent = id( "qunit-userAgent" );
+	if ( userAgent ) {
+		userAgent.innerHTML = navigator.userAgent;
+	}
+
+	// `banner` initialized at top of scope
+	banner = id( "qunit-header" );
+	if ( banner ) {
+		banner.innerHTML = "<a href='" + QUnit.url({ filter: undefined, module: undefined, testNumber: undefined }) + "'>" + banner.innerHTML + "</a> ";
+	}
+
+	// `toolbar` initialized at top of scope
+	toolbar = id( "qunit-testrunner-toolbar" );
+	if ( toolbar ) {
+		// `filter` initialized at top of scope
+		filter = document.createElement( "input" );
+		filter.type = "checkbox";
+		filter.id = "qunit-filter-pass";
+
+		addEvent( filter, "click", function() {
+			var tmp,
+				ol = document.getElementById( "qunit-tests" );
+
+			if ( filter.checked ) {
+				ol.className = ol.className + " hidepass";
+			} else {
+				tmp = " " + ol.className.replace( /[\n\t\r]/g, " " ) + " ";
+				ol.className = tmp.replace( / hidepass /, " " );
+			}
+			if ( defined.sessionStorage ) {
+				if (filter.checked) {
+					sessionStorage.setItem( "qunit-filter-passed-tests", "true" );
+				} else {
+					sessionStorage.removeItem( "qunit-filter-passed-tests" );
+				}
+			}
+		});
+
+		if ( config.hidepassed || defined.sessionStorage && sessionStorage.getItem( "qunit-filter-passed-tests" ) ) {
+			filter.checked = true;
+			// `ol` initialized at top of scope
+			ol = document.getElementById( "qunit-tests" );
+			ol.className = ol.className + " hidepass";
+		}
+		toolbar.appendChild( filter );
+
+		// `label` initialized at top of scope
+		label = document.createElement( "label" );
+		label.setAttribute( "for", "qunit-filter-pass" );
+		label.setAttribute( "title", "Only show tests and assertions that fail. Stored in sessionStorage." );
+		label.innerHTML = "Hide passed tests";
+		toolbar.appendChild( label );
+
+		urlConfigCheckboxesContainer = document.createElement("span");
+		urlConfigCheckboxesContainer.innerHTML = urlConfigHtml;
+		urlConfigCheckboxes = urlConfigCheckboxesContainer.getElementsByTagName("input");
+		// For oldIE support:
+		// * Add handlers to the individual elements instead of the container
+		// * Use "click" instead of "change"
+		// * Fallback from event.target to event.srcElement
+		addEvents( urlConfigCheckboxes, "click", function( event ) {
+			var params = {},
+				target = event.target || event.srcElement;
+			params[ target.name ] = target.checked ? true : undefined;
+			window.location = QUnit.url( params );
+		});
+		toolbar.appendChild( urlConfigCheckboxesContainer );
+
+		if (numModules > 1) {
+			moduleFilter = document.createElement( "span" );
+			moduleFilter.setAttribute( "id", "qunit-modulefilter-container" );
+			moduleFilter.innerHTML = moduleFilterHtml;
+			addEvent( moduleFilter.lastChild, "change", function() {
+				var selectBox = moduleFilter.getElementsByTagName("select")[0],
+					selectedModule = decodeURIComponent(selectBox.options[selectBox.selectedIndex].value);
+
+				window.location = QUnit.url({
+					module: ( selectedModule === "" ) ? undefined : selectedModule,
+					// Remove any existing filters
+					filter: undefined,
+					testNumber: undefined
+				});
+			});
+			toolbar.appendChild(moduleFilter);
+		}
+	}
+
+	// `main` initialized at top of scope
+	main = id( "qunit-fixture" );
+	if ( main ) {
+		config.fixture = main.innerHTML;
+	}
+
+	if ( config.autostart ) {
+		QUnit.start();
+	}
+};
+
+addEvent( window, "load", QUnit.load );
+
+// `onErrorFnPrev` initialized at top of scope
+// Preserve other handlers
+onErrorFnPrev = window.onerror;
+
+// Cover uncaught exceptions
+// Returning true will suppress the default browser handler,
+// returning false will let it run.
+window.onerror = function ( error, filePath, linerNr ) {
+	var ret = false;
+	if ( onErrorFnPrev ) {
+		ret = onErrorFnPrev( error, filePath, linerNr );
+	}
+
+	// Treat return value as window.onerror itself does,
+	// Only do our handling if not suppressed.
+	if ( ret !== true ) {
+		if ( QUnit.config.current ) {
+			if ( QUnit.config.current.ignoreGlobalErrors ) {
+				return true;
+			}
+			QUnit.pushFailure( error, filePath + ":" + linerNr );
+		} else {
+			QUnit.test( "global failure", extend( function() {
+				QUnit.pushFailure( error, filePath + ":" + linerNr );
+			}, { validTest: validTest } ) );
+		}
+		return false;
+	}
+
+	return ret;
+};
+
+function done() {
+	config.autorun = true;
+
+	// Log the last module results
+	if ( config.currentModule ) {
+		runLoggingCallbacks( "moduleDone", QUnit, {
+			name: config.currentModule,
+			failed: config.moduleStats.bad,
+			passed: config.moduleStats.all - config.moduleStats.bad,
+			total: config.moduleStats.all
+		});
+	}
+	delete config.previousModule;
+
+	var i, key,
+		banner = id( "qunit-banner" ),
+		tests = id( "qunit-tests" ),
+		runtime = +new Date() - config.started,
+		passed = config.stats.all - config.stats.bad,
+		html = [
+			"Tests completed in ",
+			runtime,
+			" milliseconds.<br/>",
+			"<span class='passed'>",
+			passed,
+			"</span> assertions of <span class='total'>",
+			config.stats.all,
+			"</span> passed, <span class='failed'>",
+			config.stats.bad,
+			"</span> failed."
+		].join( "" );
+
+	if ( banner ) {
+		banner.className = ( config.stats.bad ? "qunit-fail" : "qunit-pass" );
+	}
+
+	if ( tests ) {
+		id( "qunit-testresult" ).innerHTML = html;
+	}
+
+	if ( config.altertitle && typeof document !== "undefined" && document.title ) {
+		// show ✖ for good, ✔ for bad suite result in title
+		// use escape sequences in case file gets loaded with non-utf-8-charset
+		document.title = [
+			( config.stats.bad ? "\u2716" : "\u2714" ),
+			document.title.replace( /^[\u2714\u2716] /i, "" )
+		].join( " " );
+	}
+
+	// clear own sessionStorage items if all tests passed
+	if ( config.reorder && defined.sessionStorage && config.stats.bad === 0 ) {
+		// `key` & `i` initialized at top of scope
+		for ( i = 0; i < sessionStorage.length; i++ ) {
+			key = sessionStorage.key( i++ );
+			if ( key.indexOf( "qunit-test-" ) === 0 ) {
+				sessionStorage.removeItem( key );
+			}
+		}
+	}
+
+	// scroll back to top to show results
+	if ( window.scrollTo ) {
+		window.scrollTo(0, 0);
+	}
+
+	runLoggingCallbacks( "done", QUnit, {
+		failed: config.stats.bad,
+		passed: passed,
+		total: config.stats.all,
+		runtime: runtime
+	});
+}
+
+/** @return Boolean: true if this test should be ran */
+function validTest( test ) {
+	var include,
+		filter = config.filter && config.filter.toLowerCase(),
+		module = config.module && config.module.toLowerCase(),
+		fullName = (test.module + ": " + test.testName).toLowerCase();
+
+	// Internally-generated tests are always valid
+	if ( test.callback && test.callback.validTest === validTest ) {
+		delete test.callback.validTest;
+		return true;
+	}
+
+	if ( config.testNumber ) {
+		return test.testNumber === config.testNumber;
+	}
+
+	if ( module && ( !test.module || test.module.toLowerCase() !== module ) ) {
+		return false;
+	}
+
+	if ( !filter ) {
+		return true;
+	}
+
+	include = filter.charAt( 0 ) !== "!";
+	if ( !include ) {
+		filter = filter.slice( 1 );
+	}
+
+	// If the filter matches, we need to honour include
+	if ( fullName.indexOf( filter ) !== -1 ) {
+		return include;
+	}
+
+	// Otherwise, do the opposite
+	return !include;
+}
+
+// so far supports only Firefox, Chrome and Opera (buggy), Safari (for real exceptions)
+// Later Safari and IE10 are supposed to support error.stack as well
+// See also https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error/Stack
+function extractStacktrace( e, offset ) {
+	offset = offset === undefined ? 3 : offset;
+
+	var stack, include, i;
+
+	if ( e.stacktrace ) {
+		// Opera
+		return e.stacktrace.split( "\n" )[ offset + 3 ];
+	} else if ( e.stack ) {
+		// Firefox, Chrome
+		stack = e.stack.split( "\n" );
+		if (/^error$/i.test( stack[0] ) ) {
+			stack.shift();
+		}
+		if ( fileName ) {
+			include = [];
+			for ( i = offset; i < stack.length; i++ ) {
+				if ( stack[ i ].indexOf( fileName ) !== -1 ) {
+					break;
+				}
+				include.push( stack[ i ] );
+			}
+			if ( include.length ) {
+				return include.join( "\n" );
+			}
+		}
+		return stack[ offset ];
+	} else if ( e.sourceURL ) {
+		// Safari, PhantomJS
+		// hopefully one day Safari provides actual stacktraces
+		// exclude useless self-reference for generated Error objects
+		if ( /qunit.js$/.test( e.sourceURL ) ) {
+			return;
+		}
+		// for actual exceptions, this is useful
+		return e.sourceURL + ":" + e.line;
+	}
+}
+function sourceFromStacktrace( offset ) {
+	try {
+		throw new Error();
+	} catch ( e ) {
+		return extractStacktrace( e, offset );
+	}
+}
+
+/**
+ * Escape text for attribute or text content.
+ */
+function escapeText( s ) {
+	if ( !s ) {
+		return "";
+	}
+	s = s + "";
+	// Both single quotes and double quotes (for attributes)
+	return s.replace( /['"<>&]/g, function( s ) {
+		switch( s ) {
+			case "'":
+				return "&#039;";
+			case "\"":
+				return "&quot;";
+			case "<":
+				return "&lt;";
+			case ">":
+				return "&gt;";
+			case "&":
+				return "&amp;";
+		}
+	});
+}
+
+function synchronize( callback, last ) {
+	config.queue.push( callback );
+
+	if ( config.autorun && !config.blocking ) {
+		process( last );
+	}
+}
+
+function process( last ) {
+	function next() {
+		process( last );
+	}
+	var start = new Date().getTime();
+	config.depth = config.depth ? config.depth + 1 : 1;
+
+	while ( config.queue.length && !config.blocking ) {
+		if ( !defined.setTimeout || config.updateRate <= 0 || ( ( new Date().getTime() - start ) < config.updateRate ) ) {
+			config.queue.shift()();
+		} else {
+			setTimeout( next, 13 );
+			break;
+		}
+	}
+	config.depth--;
+	if ( last && !config.blocking && !config.queue.length && config.depth === 0 ) {
+		done();
+	}
+}
+
+function saveGlobal() {
+	config.pollution = [];
+
+	if ( config.noglobals ) {
+		for ( var key in window ) {
+			if ( hasOwn.call( window, key ) ) {
+				// in Opera sometimes DOM element ids show up here, ignore them
+				if ( /^qunit-test-output/.test( key ) ) {
+					continue;
+				}
+				config.pollution.push( key );
+			}
+		}
+	}
+}
+
+function checkPollution() {
+	var newGlobals,
+		deletedGlobals,
+		old = config.pollution;
+
+	saveGlobal();
+
+	newGlobals = diff( config.pollution, old );
+	if ( newGlobals.length > 0 ) {
+		QUnit.pushFailure( "Introduced global variable(s): " + newGlobals.join(", ") );
+	}
+
+	deletedGlobals = diff( old, config.pollution );
+	if ( deletedGlobals.length > 0 ) {
+		QUnit.pushFailure( "Deleted global variable(s): " + deletedGlobals.join(", ") );
+	}
+}
+
+// returns a new Array with the elements that are in a but not in b
+function diff( a, b ) {
+	var i, j,
+		result = a.slice();
+
+	for ( i = 0; i < result.length; i++ ) {
+		for ( j = 0; j < b.length; j++ ) {
+			if ( result[i] === b[j] ) {
+				result.splice( i, 1 );
+				i--;
+				break;
+			}
+		}
+	}
+	return result;
+}
+
+function extend( a, b ) {
+	for ( var prop in b ) {
+		if ( hasOwn.call( b, prop ) ) {
+			// Avoid "Member not found" error in IE8 caused by messing with window.constructor
+			if ( !( prop === "constructor" && a === window ) ) {
+				if ( b[ prop ] === undefined ) {
+					delete a[ prop ];
+				} else {
+					a[ prop ] = b[ prop ];
+				}
+			}
+		}
+	}
+
+	return a;
+}
+
+/**
+ * @param {HTMLElement} elem
+ * @param {string} type
+ * @param {Function} fn
+ */
+function addEvent( elem, type, fn ) {
+	// Standards-based browsers
+	if ( elem.addEventListener ) {
+		elem.addEventListener( type, fn, false );
+	// IE
+	} else {
+		elem.attachEvent( "on" + type, fn );
+	}
+}
+
+/**
+ * @param {Array|NodeList} elems
+ * @param {string} type
+ * @param {Function} fn
+ */
+function addEvents( elems, type, fn ) {
+	var i = elems.length;
+	while ( i-- ) {
+		addEvent( elems[i], type, fn );
+	}
+}
+
+function hasClass( elem, name ) {
+	return (" " + elem.className + " ").indexOf(" " + name + " ") > -1;
+}
+
+function addClass( elem, name ) {
+	if ( !hasClass( elem, name ) ) {
+		elem.className += (elem.className ? " " : "") + name;
+	}
+}
+
+function removeClass( elem, name ) {
+	var set = " " + elem.className + " ";
+	// Class name may appear multiple times
+	while ( set.indexOf(" " + name + " ") > -1 ) {
+		set = set.replace(" " + name + " " , " ");
+	}
+	// If possible, trim it for prettiness, but not necessarily
+	elem.className = typeof set.trim === "function" ? set.trim() : set.replace(/^\s+|\s+$/g, "");
+}
+
+function id( name ) {
+	return !!( typeof document !== "undefined" && document && document.getElementById ) &&
+		document.getElementById( name );
+}
+
+function registerLoggingCallback( key ) {
+	return function( callback ) {
+		config[key].push( callback );
+	};
+}
+
+// Supports deprecated method of completely overwriting logging callbacks
+function runLoggingCallbacks( key, scope, args ) {
+	var i, callbacks;
+	if ( QUnit.hasOwnProperty( key ) ) {
+		QUnit[ key ].call(scope, args );
+	} else {
+		callbacks = config[ key ];
+		for ( i = 0; i < callbacks.length; i++ ) {
+			callbacks[ i ].call( scope, args );
+		}
+	}
+}
+
+// Test for equality any JavaScript type.
+// Author: Philippe Rathé <prathe@gmail.com>
+QUnit.equiv = (function() {
+
+	// Call the o related callback with the given arguments.
+	function bindCallbacks( o, callbacks, args ) {
+		var prop = QUnit.objectType( o );
+		if ( prop ) {
+			if ( QUnit.objectType( callbacks[ prop ] ) === "function" ) {
+				return callbacks[ prop ].apply( callbacks, args );
+			} else {
+				return callbacks[ prop ]; // or undefined
+			}
+		}
+	}
+
+	// the real equiv function
+	var innerEquiv,
+		// stack to decide between skip/abort functions
+		callers = [],
+		// stack to avoiding loops from circular referencing
+		parents = [],
+		parentsB = [],
+
+		getProto = Object.getPrototypeOf || function ( obj ) {
+			/*jshint camelcase:false */
+			return obj.__proto__;
+		},
+		callbacks = (function () {
+
+			// for string, boolean, number and null
+			function useStrictEquality( b, a ) {
+				/*jshint eqeqeq:false */
+				if ( b instanceof a.constructor || a instanceof b.constructor ) {
+					// to catch short annotation VS 'new' annotation of a
+					// declaration
+					// e.g. var i = 1;
+					// var j = new Number(1);
+					return a == b;
+				} else {
+					return a === b;
+				}
+			}
+
+			return {
+				"string": useStrictEquality,
+				"boolean": useStrictEquality,
+				"number": useStrictEquality,
+				"null": useStrictEquality,
+				"undefined": useStrictEquality,
+
+				"nan": function( b ) {
+					return isNaN( b );
+				},
+
+				"date": function( b, a ) {
+					return QUnit.objectType( b ) === "date" && a.valueOf() === b.valueOf();
+				},
+
+				"regexp": function( b, a ) {
+					return QUnit.objectType( b ) === "regexp" &&
+						// the regex itself
+						a.source === b.source &&
+						// and its modifiers
+						a.global === b.global &&
+						// (gmi) ...
+						a.ignoreCase === b.ignoreCase &&
+						a.multiline === b.multiline &&
+						a.sticky === b.sticky;
+				},
+
+				// - skip when the property is a method of an instance (OOP)
+				// - abort otherwise,
+				// initial === would have catch identical references anyway
+				"function": function() {
+					var caller = callers[callers.length - 1];
+					return caller !== Object && typeof caller !== "undefined";
+				},
+
+				"array": function( b, a ) {
+					var i, j, len, loop, aCircular, bCircular;
+
+					// b could be an object literal here
+					if ( QUnit.objectType( b ) !== "array" ) {
+						return false;
+					}
+
+					len = a.length;
+					if ( len !== b.length ) {
+						// safe and faster
+						return false;
+					}
+
+					// track reference to avoid circular references
+					parents.push( a );
+					parentsB.push( b );
+					for ( i = 0; i < len; i++ ) {
+						loop = false;
+						for ( j = 0; j < parents.length; j++ ) {
+							aCircular = parents[j] === a[i];
+							bCircular = parentsB[j] === b[i];
+							if ( aCircular || bCircular ) {
+								if ( a[i] === b[i] || aCircular && bCircular ) {
+									loop = true;
+								} else {
+									parents.pop();
+									parentsB.pop();
+									return false;
+								}
+							}
+						}
+						if ( !loop && !innerEquiv(a[i], b[i]) ) {
+							parents.pop();
+							parentsB.pop();
+							return false;
+						}
+					}
+					parents.pop();
+					parentsB.pop();
+					return true;
+				},
+
+				"object": function( b, a ) {
+					/*jshint forin:false */
+					var i, j, loop, aCircular, bCircular,
+						// Default to true
+						eq = true,
+						aProperties = [],
+						bProperties = [];
+
+					// comparing constructors is more strict than using
+					// instanceof
+					if ( a.constructor !== b.constructor ) {
+						// Allow objects with no prototype to be equivalent to
+						// objects with Object as their constructor.
+						if ( !(( getProto(a) === null && getProto(b) === Object.prototype ) ||
+							( getProto(b) === null && getProto(a) === Object.prototype ) ) ) {
+								return false;
+						}
+					}
+
+					// stack constructor before traversing properties
+					callers.push( a.constructor );
+
+					// track reference to avoid circular references
+					parents.push( a );
+					parentsB.push( b );
+
+					// be strict: don't ensure hasOwnProperty and go deep
+					for ( i in a ) {
+						loop = false;
+						for ( j = 0; j < parents.length; j++ ) {
+							aCircular = parents[j] === a[i];
+							bCircular = parentsB[j] === b[i];
+							if ( aCircular || bCircular ) {
+								if ( a[i] === b[i] || aCircular && bCircular ) {
+									loop = true;
+								} else {
+									eq = false;
+									break;
+								}
+							}
+						}
+						aProperties.push(i);
+						if ( !loop && !innerEquiv(a[i], b[i]) ) {
+							eq = false;
+							break;
+						}
+					}
+
+					parents.pop();
+					parentsB.pop();
+					callers.pop(); // unstack, we are done
+
+					for ( i in b ) {
+						bProperties.push( i ); // collect b's properties
+					}
+
+					// Ensures identical properties name
+					return eq && innerEquiv( aProperties.sort(), bProperties.sort() );
+				}
+			};
+		}());
+
+	innerEquiv = function() { // can take multiple arguments
+		var args = [].slice.apply( arguments );
+		if ( args.length < 2 ) {
+			return true; // end transition
+		}
+
+		return (function( a, b ) {
+			if ( a === b ) {
+				return true; // catch the most you can
+			} else if ( a === null || b === null || typeof a === "undefined" ||
+					typeof b === "undefined" ||
+					QUnit.objectType(a) !== QUnit.objectType(b) ) {
+				return false; // don't lose time with error prone cases
+			} else {
+				return bindCallbacks(a, callbacks, [ b, a ]);
+			}
+
+			// apply transition with (1..n) arguments
+		}( args[0], args[1] ) && innerEquiv.apply( this, args.splice(1, args.length - 1 )) );
+	};
+
+	return innerEquiv;
+}());
+
+/**
+ * jsDump Copyright (c) 2008 Ariel Flesler - aflesler(at)gmail(dot)com |
+ * http://flesler.blogspot.com Licensed under BSD
+ * (http://www.opensource.org/licenses/bsd-license.php) Date: 5/15/2008
+ *
+ * @projectDescription Advanced and extensible data dumping for Javascript.
+ * @version 1.0.0
+ * @author Ariel Flesler
+ * @link {http://flesler.blogspot.com/2008/05/jsdump-pretty-dump-of-any-javascript.html}
+ */
+QUnit.jsDump = (function() {
+	function quote( str ) {
+		return "\"" + str.toString().replace( /"/g, "\\\"" ) + "\"";
+	}
+	function literal( o ) {
+		return o + "";
+	}
+	function join( pre, arr, post ) {
+		var s = jsDump.separator(),
+			base = jsDump.indent(),
+			inner = jsDump.indent(1);
+		if ( arr.join ) {
+			arr = arr.join( "," + s + inner );
+		}
+		if ( !arr ) {
+			return pre + post;
+		}
+		return [ pre, inner + arr, base + post ].join(s);
+	}
+	function array( arr, stack ) {
+		var i = arr.length, ret = new Array(i);
+		this.up();
+		while ( i-- ) {
+			ret[i] = this.parse( arr[i] , undefined , stack);
+		}
+		this.down();
+		return join( "[", ret, "]" );
+	}
+
+	var reName = /^function (\w+)/,
+		jsDump = {
+			// type is used mostly internally, you can fix a (custom)type in advance
+			parse: function( obj, type, stack ) {
+				stack = stack || [ ];
+				var inStack, res,
+					parser = this.parsers[ type || this.typeOf(obj) ];
+
+				type = typeof parser;
+				inStack = inArray( obj, stack );
+
+				if ( inStack !== -1 ) {
+					return "recursion(" + (inStack - stack.length) + ")";
+				}
+				if ( type === "function" )  {
+					stack.push( obj );
+					res = parser.call( this, obj, stack );
+					stack.pop();
+					return res;
+				}
+				return ( type === "string" ) ? parser : this.parsers.error;
+			},
+			typeOf: function( obj ) {
+				var type;
+				if ( obj === null ) {
+					type = "null";
+				} else if ( typeof obj === "undefined" ) {
+					type = "undefined";
+				} else if ( QUnit.is( "regexp", obj) ) {
+					type = "regexp";
+				} else if ( QUnit.is( "date", obj) ) {
+					type = "date";
+				} else if ( QUnit.is( "function", obj) ) {
+					type = "function";
+				} else if ( typeof obj.setInterval !== undefined && typeof obj.document !== "undefined" && typeof obj.nodeType === "undefined" ) {
+					type = "window";
+				} else if ( obj.nodeType === 9 ) {
+					type = "document";
+				} else if ( obj.nodeType ) {
+					type = "node";
+				} else if (
+					// native arrays
+					toString.call( obj ) === "[object Array]" ||
+					// NodeList objects
+					( typeof obj.length === "number" && typeof obj.item !== "undefined" && ( obj.length ? obj.item(0) === obj[0] : ( obj.item( 0 ) === null && typeof obj[0] === "undefined" ) ) )
+				) {
+					type = "array";
+				} else if ( obj.constructor === Error.prototype.constructor ) {
+					type = "error";
+				} else {
+					type = typeof obj;
+				}
+				return type;
+			},
+			separator: function() {
+				return this.multiline ?	this.HTML ? "<br />" : "\n" : this.HTML ? "&nbsp;" : " ";
+			},
+			// extra can be a number, shortcut for increasing-calling-decreasing
+			indent: function( extra ) {
+				if ( !this.multiline ) {
+					return "";
+				}
+				var chr = this.indentChar;
+				if ( this.HTML ) {
+					chr = chr.replace( /\t/g, "   " ).replace( / /g, "&nbsp;" );
+				}
+				return new Array( this.depth + ( extra || 0 ) ).join(chr);
+			},
+			up: function( a ) {
+				this.depth += a || 1;
+			},
+			down: function( a ) {
+				this.depth -= a || 1;
+			},
+			setParser: function( name, parser ) {
+				this.parsers[name] = parser;
+			},
+			// The next 3 are exposed so you can use them
+			quote: quote,
+			literal: literal,
+			join: join,
+			//
+			depth: 1,
+			// This is the list of parsers, to modify them, use jsDump.setParser
+			parsers: {
+				window: "[Window]",
+				document: "[Document]",
+				error: function(error) {
+					return "Error(\"" + error.message + "\")";
+				},
+				unknown: "[Unknown]",
+				"null": "null",
+				"undefined": "undefined",
+				"function": function( fn ) {
+					var ret = "function",
+						// functions never have name in IE
+						name = "name" in fn ? fn.name : (reName.exec(fn) || [])[1];
+
+					if ( name ) {
+						ret += " " + name;
+					}
+					ret += "( ";
+
+					ret = [ ret, QUnit.jsDump.parse( fn, "functionArgs" ), "){" ].join( "" );
+					return join( ret, QUnit.jsDump.parse(fn,"functionCode" ), "}" );
+				},
+				array: array,
+				nodelist: array,
+				"arguments": array,
+				object: function( map, stack ) {
+					/*jshint forin:false */
+					var ret = [ ], keys, key, val, i;
+					QUnit.jsDump.up();
+					keys = [];
+					for ( key in map ) {
+						keys.push( key );
+					}
+					keys.sort();
+					for ( i = 0; i < keys.length; i++ ) {
+						key = keys[ i ];
+						val = map[ key ];
+						ret.push( QUnit.jsDump.parse( key, "key" ) + ": " + QUnit.jsDump.parse( val, undefined, stack ) );
+					}
+					QUnit.jsDump.down();
+					return join( "{", ret, "}" );
+				},
+				node: function( node ) {
+					var len, i, val,
+						open = QUnit.jsDump.HTML ? "&lt;" : "<",
+						close = QUnit.jsDump.HTML ? "&gt;" : ">",
+						tag = node.nodeName.toLowerCase(),
+						ret = open + tag,
+						attrs = node.attributes;
+
+					if ( attrs ) {
+						for ( i = 0, len = attrs.length; i < len; i++ ) {
+							val = attrs[i].nodeValue;
+							// IE6 includes all attributes in .attributes, even ones not explicitly set.
+							// Those have values like undefined, null, 0, false, "" or "inherit".
+							if ( val && val !== "inherit" ) {
+								ret += " " + attrs[i].nodeName + "=" + QUnit.jsDump.parse( val, "attribute" );
+							}
+						}
+					}
+					ret += close;
+
+					// Show content of TextNode or CDATASection
+					if ( node.nodeType === 3 || node.nodeType === 4 ) {
+						ret += node.nodeValue;
+					}
+
+					return ret + open + "/" + tag + close;
+				},
+				// function calls it internally, it's the arguments part of the function
+				functionArgs: function( fn ) {
+					var args,
+						l = fn.length;
+
+					if ( !l ) {
+						return "";
+					}
+
+					args = new Array(l);
+					while ( l-- ) {
+						// 97 is 'a'
+						args[l] = String.fromCharCode(97+l);
+					}
+					return " " + args.join( ", " ) + " ";
+				},
+				// object calls it internally, the key part of an item in a map
+				key: quote,
+				// function calls it internally, it's the content of the function
+				functionCode: "[code]",
+				// node calls it internally, it's an html attribute value
+				attribute: quote,
+				string: quote,
+				date: quote,
+				regexp: literal,
+				number: literal,
+				"boolean": literal
+			},
+			// if true, entities are escaped ( <, >, \t, space and \n )
+			HTML: false,
+			// indentation unit
+			indentChar: "  ",
+			// if true, items in a collection, are separated by a \n, else just a space.
+			multiline: true
+		};
+
+	return jsDump;
+}());
+
+// from jquery.js
+function inArray( elem, array ) {
+	if ( array.indexOf ) {
+		return array.indexOf( elem );
+	}
+
+	for ( var i = 0, length = array.length; i < length; i++ ) {
+		if ( array[ i ] === elem ) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+/*
+ * Javascript Diff Algorithm
+ *  By John Resig (http://ejohn.org/)
+ *  Modified by Chu Alan "sprite"
+ *
+ * Released under the MIT license.
+ *
+ * More Info:
+ *  http://ejohn.org/projects/javascript-diff-algorithm/
+ *
+ * Usage: QUnit.diff(expected, actual)
+ *
+ * QUnit.diff( "the quick brown fox jumped over", "the quick fox jumps over" ) == "the  quick <del>brown </del> fox <del>jumped </del><ins>jumps </ins> over"
+ */
+QUnit.diff = (function() {
+	/*jshint eqeqeq:false, eqnull:true */
+	function diff( o, n ) {
+		var i,
+			ns = {},
+			os = {};
+
+		for ( i = 0; i < n.length; i++ ) {
+			if ( !hasOwn.call( ns, n[i] ) ) {
+				ns[ n[i] ] = {
+					rows: [],
+					o: null
+				};
+			}
+			ns[ n[i] ].rows.push( i );
+		}
+
+		for ( i = 0; i < o.length; i++ ) {
+			if ( !hasOwn.call( os, o[i] ) ) {
+				os[ o[i] ] = {
+					rows: [],
+					n: null
+				};
+			}
+			os[ o[i] ].rows.push( i );
+		}
+
+		for ( i in ns ) {
+			if ( hasOwn.call( ns, i ) ) {
+				if ( ns[i].rows.length === 1 && hasOwn.call( os, i ) && os[i].rows.length === 1 ) {
+					n[ ns[i].rows[0] ] = {
+						text: n[ ns[i].rows[0] ],
+						row: os[i].rows[0]
+					};
+					o[ os[i].rows[0] ] = {
+						text: o[ os[i].rows[0] ],
+						row: ns[i].rows[0]
+					};
+				}
+			}
+		}
+
+		for ( i = 0; i < n.length - 1; i++ ) {
+			if ( n[i].text != null && n[ i + 1 ].text == null && n[i].row + 1 < o.length && o[ n[i].row + 1 ].text == null &&
+						n[ i + 1 ] == o[ n[i].row + 1 ] ) {
+
+				n[ i + 1 ] = {
+					text: n[ i + 1 ],
+					row: n[i].row + 1
+				};
+				o[ n[i].row + 1 ] = {
+					text: o[ n[i].row + 1 ],
+					row: i + 1
+				};
+			}
+		}
+
+		for ( i = n.length - 1; i > 0; i-- ) {
+			if ( n[i].text != null && n[ i - 1 ].text == null && n[i].row > 0 && o[ n[i].row - 1 ].text == null &&
+						n[ i - 1 ] == o[ n[i].row - 1 ]) {
+
+				n[ i - 1 ] = {
+					text: n[ i - 1 ],
+					row: n[i].row - 1
+				};
+				o[ n[i].row - 1 ] = {
+					text: o[ n[i].row - 1 ],
+					row: i - 1
+				};
+			}
+		}
+
+		return {
+			o: o,
+			n: n
+		};
+	}
+
+	return function( o, n ) {
+		o = o.replace( /\s+$/, "" );
+		n = n.replace( /\s+$/, "" );
+
+		var i, pre,
+			str = "",
+			out = diff( o === "" ? [] : o.split(/\s+/), n === "" ? [] : n.split(/\s+/) ),
+			oSpace = o.match(/\s+/g),
+			nSpace = n.match(/\s+/g);
+
+		if ( oSpace == null ) {
+			oSpace = [ " " ];
+		}
+		else {
+			oSpace.push( " " );
+		}
+
+		if ( nSpace == null ) {
+			nSpace = [ " " ];
+		}
+		else {
+			nSpace.push( " " );
+		}
+
+		if ( out.n.length === 0 ) {
+			for ( i = 0; i < out.o.length; i++ ) {
+				str += "<del>" + out.o[i] + oSpace[i] + "</del>";
+			}
+		}
+		else {
+			if ( out.n[0].text == null ) {
+				for ( n = 0; n < out.o.length && out.o[n].text == null; n++ ) {
+					str += "<del>" + out.o[n] + oSpace[n] + "</del>";
+				}
+			}
+
+			for ( i = 0; i < out.n.length; i++ ) {
+				if (out.n[i].text == null) {
+					str += "<ins>" + out.n[i] + nSpace[i] + "</ins>";
+				}
+				else {
+					// `pre` initialized at top of scope
+					pre = "";
+
+					for ( n = out.n[i].row + 1; n < out.o.length && out.o[n].text == null; n++ ) {
+						pre += "<del>" + out.o[n] + oSpace[n] + "</del>";
+					}
+					str += " " + out.n[i].text + nSpace[i] + pre;
+				}
+			}
+		}
+
+		return str;
+	};
+}());
+
+// for CommonJS environments, export everything
+if ( typeof exports !== "undefined" ) {
+	extend( exports, QUnit.constructor.prototype );
+}
+
+// get at whatever the global object is, like window in browsers
+}( (function() {return this;}.call()) ));

--- a/oabutton/static/test/test.html
+++ b/oabutton/static/test/test.html
@@ -1,0 +1,16 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+      <meta title="utf-8">
+      <title>OAButton JavaScript tests</title>
+      <link href="resources/qunit.css" rel="stylesheet" />
+  </head>
+  <body>
+      <div id="qunit"></div>
+      <div id="qunit-fixture"></div>
+      <script src="resources/qunit.js"></script>
+      <script src="../public/js/jquery.min.js"></script>
+      <script src="../public/js/success.js"></script>
+      <script src="test.js"></script>
+  </body>
+</html>

--- a/oabutton/static/test/test.html
+++ b/oabutton/static/test/test.html
@@ -10,6 +10,7 @@
       <div id="qunit-fixture"></div>
       <script src="resources/qunit.js"></script>
       <script src="../public/js/jquery.min.js"></script>
+      <script src="resources/jquery.mockjax.js"></script>
       <script src="../public/js/success.js"></script>
       <script src="test.js"></script>
   </body>

--- a/oabutton/static/test/test.js
+++ b/oabutton/static/test/test.js
@@ -42,3 +42,29 @@ test( "addScholarTitleLink", function() {
   ok(link.attr('href').indexOf('scholar.google.com') > -1, "Link goes to Google Scholar");
   ok(link.attr('href').indexOf(encodeURIComponent(this.metadata.title)) > -1, "Link href contains the DOI");
 });
+
+asyncTest( "discoverCORELinks", function() {
+  expect(3);
+
+  var $fixture = $('#qunit-fixture');
+  $fixture.append('<ul id="oa_links"></ul>');
+
+  $.mockjax({
+    url: "/metadata/coresearch.json/*",
+    responseText: {"ListRecords":[{"total_hits":5015},{"record":{"header":{"header:content":{"core:repositoryIdentifier":"143","identifier":"669636"},"header:attr":{"xmlns:core":"http:\/\/core.kmi.open.ac.uk\/api\/doc"}},"metadata":{"oai_dc:dc":{"oai_dc:ns":[{"xmlns:oai_dc":"http:\/\/www.openarchives.org\/OAI\/2.0\/oai_dc\/","xmlns:dc":"http:\/\/purl.org\/dc\/elements\/1.1\/"}],"dc:creator":"R Kudyar","dc:format":"application\/pdf","dc:source":"http:\/\/www.jkscience.org\/archive\/111\/18-RL-JACORD%20ARTHRITIS.pdf","dc:date":"2009","dc:identifier":"http:\/\/www.jkscience.org\/archive\/111\/18-RL-JACORD%20ARTHRITIS.pdf","dc:description":"A case of a patient with rheumatic valvulardisease who had comparable deformities of the handsand fingers and who fulfilled all of the criteriasuggested by Bywaters to describe Jaccoud's Arthritis is decribed here.","dc:title":"Jaccoud\u2019s Arthritis"}}}},{"record":{"header":{"header:content":{"core:repositoryIdentifier":"140","identifier":"60225"},"header:attr":{"xmlns:core":"http:\/\/core.kmi.open.ac.uk\/api\/doc"}},"metadata":{"oai_dc:dc":{"oai_dc:ns":[{"xmlns:oai_dc":"http:\/\/www.openarchives.org\/OAI\/2.0\/oai_dc\/","xmlns:dc":"http:\/\/purl.org\/dc\/elements\/1.1\/"}],"dc:creator":"Zai Liu, Guo Deng, Simon Foster and Andrej Tarkowski","dc:format":"application\/pdf","dc:source":"http:\/\/eprints.whiterose.ac.uk\/21\/1\/ar330.pdf","dc:date":"2001-09-17","dc:identifier":"http:\/\/eprints.whiterose.ac.uk\/21\/1\/ar330.pdf","dc:description":"Staphylococcus aureus is one of the most important pathogens in septic arthritis. To analyse the arthritogenic properties of staphylococcal peptidoglycan (PGN), highly purified PGN from S. aureus was intra-articularly injected into murine joints. The results demonstrate that PGN will trigger arthritis in a dose-dependent manner. A single injection of this compound leads to massive infiltration of predominantly macrophages and polymorphonuclear cells with occasional signs of cartilage and\/or bone destruction, lasting for at least 14 days. Further studies showed that this condition is mediated by the combined impact of acquired and innate immune systems. Our results indicate that PGN exerts a central role in joint inflammation triggered by S. aureus.","dc:title":"Staphylococcal peptidoglycans induce arthritis"}}}},{"record":{"header":{"header:content":{"core:repositoryIdentifier":"143","identifier":"5726004"},"header:attr":{"xmlns:core":"http:\/\/core.kmi.open.ac.uk\/api\/doc"}},"metadata":{"oai_dc:dc":{"oai_dc:ns":[{"xmlns:oai_dc":"http:\/\/www.openarchives.org\/OAI\/2.0\/oai_dc\/","xmlns:dc":"http:\/\/purl.org\/dc\/elements\/1.1\/"}],"dc:creator":"Karambin Mohammad Mehdi and Hashemian Hooman","dc:format":"application\/pdf","dc:source":"http:\/\/journals.tums.ac.ir\/PdfMed.aspx?pdf_med=\/upload_files\/pdf\/12751.pdf&manuscript_id=12751","dc:date":"2009","dc:identifier":"http:\/\/journals.tums.ac.ir\/PdfMed.aspx?pdf_med=\/upload_files\/pdf\/12751.pdf&manuscript_id=12751","dc:description":"To determine the rate of different types of arthritis in children. We prepared a retrospective descriptive study and included the whole 100 cases of arthritis referred to 17-Shahrivar Hospital, Rasht, Guilan during a 3 years period. Using their medical files, data including age, sex, season of admission, history of trauma, signs and symptoms, lab findings and duration of hospitalization were collected. SPSS 13.0 (statistical software) applied for statistical analysis. The most common age of involvement ranged 6-9 years. Septic arthritis, brucellosis, and rheumatoid fever were the most frequent causes of arthritis in our study. Fever and restricted range of motion had the highest rate among different signs and symptoms. Lab data demonstrated leukocytosis, positive CRP, and increased ESR among 74, 79.5, and 73 percent of our patients, respectively. According to the high prevalence of septic arthritis and the arthritis due to brucellosis and rheumatoid fever, it seems that mentioned diseases are still major problems in the issue of hygiene management.","dc:title":"Childhood Arthritis: Rate of Different Types"}}}}]},
+  });
+
+  oabSuccess.discoverCORELinks(this.metadata);
+
+  setTimeout(function() {
+    var link = $("a", $fixture);
+    equal(link.length, 3, "Three links added");
+
+    link = $("a:contains('Jaccoud\u2019s Arthritis')", $fixture);
+    equal(link.length, 1, "Link with 'Jaccoud\u2019s Arthritis' added");
+    equal(link.attr('href'), "http:\/\/www.jkscience.org\/archive\/111\/18-RL-JACORD%20ARTHRITIS.pdf",
+	  "Link points to correct PDF");
+
+    start();
+  }, 500);
+});

--- a/oabutton/static/test/test.js
+++ b/oabutton/static/test/test.js
@@ -1,0 +1,44 @@
+module("success.js", {
+  setup: function() {
+    this.doi = "10.1038/nrrheum.2013.47";
+    this.metadata = {
+      doi: this.doi,
+      title: "Acute inflammatory arthritis: Monoarthritis risk stratification in Lyme disease",
+      authors: "Robert T. Schoen",
+      publication: "Nature Reviews Rheumatology",
+      date: "2013-4-9",
+    };
+  },
+});
+
+test( "parseCrossRef", function() {
+  var entry = {"title":"Acute inflammatory arthritis: Monoarthritis risk stratification in Lyme disease","link":{"href":"http://dx.doi.org/10.1038%2Fnrrheum.2013.47"},"id":"http://dx.doi.org/10.1038/nrrheum.2013.47","updated":"2013-09-23T06:07:17-04:00","content":{"div":{"p":[{"b":"Acute inflammatory arthritis: Monoarthritis risk stratification in Lyme disease"},"\n\tNature Reviews Rheumatology. \n\t<ahref=\"http://dx.doi.org/10.1038%2Fnrrheum.2013.47\">10.1038/nrrheum.2013.47</a>","\n\tAuthors:\n\t\n\t\n\tRobert T. Schoen\n\t\n\t\n\t\n      "],"xmlns":"http://www.w3.org/1999/xhtml"},"type":"xhtml"},"pam:message":{"pam:article":{"xhtml:head":{"xmlns:xhtml":"http://www.w3.org/1999/xhtml"},"dc:identifier":"10.1038/nrrheum.2013.47","dc:title":"Acute inflammatory arthritis: Monoarthritis risk stratification in Lyme disease","dc:publisher":"Nature Publishing Group","dc:isPartOf":"1759-4790","prism:alternateTitle":"Nature Reviews Rheumatology","dc:creator":"Robert T. Schoen","prism:publicationName":"Nature Reviews Rheumatology","prism:issn":"1759-4790","prism:eIssn":"1759-4804","prism:doi":"10.1038/nrrheum.2013.47","prism:publicationDate":"2013-4-9","prism:volume":"9","prism:startingPage":"261","prism:endingPage":"262","prism:url":"http://dx.doi.org/10.1038%2Fnrrheum.2013.47"},"xmlns:pam":"http://prismstandard.org/namespaces/pam/2.0/","xsi:schemaLocation":"http://prismstandard.org/namespaces/pam/2.0/ \n\t\t\t\t   http://www.prismstandard.org/schemas/pam/2.1/pam.xsd"}};
+
+  var result = oabSuccess.parseCrossRef(entry, this.doi);
+
+  deepEqual(result, this.metadata, "Parses data correctly");
+});
+
+test( "addScholarDOILink", function() {
+  var $fixture = $('#qunit-fixture');
+  $fixture.append('<ul id="oa_links"></ul>');
+
+  oabSuccess.addScholarDOILink(this.metadata);
+
+  var link = $("a", $fixture);
+  equal(link.length, 1, "Only one link added");
+  ok(link.attr('href').indexOf('scholar.google.com') > -1, "Link goes to Google Scholar");
+  ok(link.attr('href').indexOf(encodeURIComponent(this.metadata.doi)) > -1, "Link href contains the DOI");
+});
+
+test( "addScholarTitleLink", function() {
+  var $fixture = $('#qunit-fixture');
+  $fixture.append('<ul id="oa_links"></ul>');
+
+  oabSuccess.addScholarTitleLink(this.metadata);
+
+  var link = $("a", $fixture);
+  equal(link.length, 1, "Only one link added");
+  ok(link.attr('href').indexOf('scholar.google.com') > -1, "Link goes to Google Scholar");
+  ok(link.attr('href').indexOf(encodeURIComponent(this.metadata.title)) > -1, "Link href contains the DOI");
+});

--- a/oabutton/urls.py
+++ b/oabutton/urls.py
@@ -14,6 +14,9 @@ urlpatterns = patterns('',
                        url(r'^api/', include(
                            'oabutton.apps.bookmarklet.urls')),
 
+                       url(r'^metadata/', include(
+                           'oabutton.apps.metadata.urls')),
+
                        # Uncomment the next line to enable the admin:
                        url(r'^admin/', include(admin.site.urls)),
                        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,5 @@ pymongo==2.5.2
 python-openid==2.2.5
 static==0.4
 wsgiref==0.1.2
+httpretty==0.6.3
+requests==2.0.0


### PR DESCRIPTION
Addresses #101.

Ok, so after you submit the form, this will now do a title search (searching by DOI isn't possible) in [CORE](http://core.kmi.open.ac.uk) and link to the full-text of the top ten hits. Obviously, this only works for papers which are cached in CORE: try it with [this paywalled Nature paper](http://www.nature.com/nphoton/journal/v4/n8/full/nphoton.2010.179.html).

I had to add some server-side stuff to proxy the calls to the CORE API because it doesn't set the `Access-Control-Allow-Origin:` header which means modern browsers won't let us do an XHR to it from JavaScript (see [Cross-origin resource sharing](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) if you've not come across this before). It also has the added benefit of keeping our API key private because it's only needed on the server.

For the CORE stuff to work, you need to set the CORE_API_KEY environment variable before starting the server. Also, I added a couple of requirements in `requirements.txt`, so you'll need to `pip install -r requirements.txt` again.

Definitely some polishing required, but I'll wait and see what people make of this before deciding what needs doing.
