### PR TITLE
Integration of social media

### DIFF
--- a/oabutton/apps/bookmarklet/templates/bookmarklet/success.html
+++ b/oabutton/apps/bookmarklet/templates/bookmarklet/success.html
@@ -11,11 +11,22 @@
 <p>
 <a href="https://twitter.com/OA_Button" class="twitter-follow-button" data-show-count="true" data-lang="en" data-size="large">Follow @OA_Button</a>
 <a href='https://twitter.com/share?url=http://openaccessbutton.org&text=I hit a #paywall trying to access {{ url }}! Help me demand open access at&via=OA_Button&related=OA_Button' class="twitter-share-button" data-lang="en" data-size="large">Tweet</a> 
+<div class="fb-like" data-href="https://www.facebook.com/openaccessbutton" data-width="300" data-layout="button_count" data-action="like" data-show-faces="true" data-share="false"></div>
+<div class="fb-share-button" data-href="https://www.facebook.com/openaccessbutton" data-width="300" data-type="button_count"></div>
+<div class="fb-send" data-href="https://www.facebook.com/openaccessbutton" data-colorscheme="light"></div>
 </p>
 
 {% endblock %}
 {% block scripts %}
 <script src="/static/js/success.js"></script>
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+<div id="fb-root"></div>
+<script>(function(d, s, id) {
+  var js, fjs = d.getElementsByTagName(s)[0];
+  if (d.getElementById(id)) return;
+  js = d.createElement(s); js.id = id;
+  js.src = "//connect.facebook.net/en_US/all.js#xfbml=1&appId=570391483000074";
+  fjs.parentNode.insertBefore(js, fjs);
+}(document, 'script', 'facebook-jssdk'));</script>
 {% endblock %}
 {% block body_attrs %}data-doi="{{doi|urlencode}}"{% endblock %}

--- a/oabutton/apps/bookmarklet/templates/bookmarklet/success.html
+++ b/oabutton/apps/bookmarklet/templates/bookmarklet/success.html
@@ -10,12 +10,12 @@
 
 <p>
 <a href="https://twitter.com/OA_Button" class="twitter-follow-button" data-show-count="true" data-lang="en" data-size="large">Follow @OA_Button</a>
-<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 <a href='https://twitter.com/share?url=http://openaccessbutton.org&text=I hit a #paywall trying to access {{ url }}! Help me demand open access at&via=OA_Button&related=OA_Button' class="twitter-share-button" data-lang="en" data-size="large">Tweet</a> 
-<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 </p>
 
 {% endblock %}
 {% block scripts %}
-<script src="/static/js/success.js"></script>{% endblock %}
+<script src="/static/js/success.js"></script>
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+{% endblock %}
 {% block body_attrs %}data-doi="{{doi|urlencode}}"{% endblock %}

--- a/oabutton/apps/bookmarklet/templates/bookmarklet/success.html
+++ b/oabutton/apps/bookmarklet/templates/bookmarklet/success.html
@@ -3,10 +3,14 @@
 <p>Now to find an Open Access version…</p>
 <ul id="oa_links">
 </ul>
+
 <p>
 <a href="http://en.wikipedia.org/wiki/Digital_object_identifier" target="_blank">What's a DOI?</a>
 </p>
+
 <p>
+<a href="https://twitter.com/OA_Button" class="twitter-follow-button" data-show-count="true" data-lang="en" data-size="large">Follow @OA_Button</a>
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 <a href='https://twitter.com/share?url=http://openaccessbutton.org&text=I hit a #paywall trying to access {{ url }}! Help me demand open access at&via=OA_Button&related=OA_Button' class="twitter-share-button" data-lang="en" data-size="large">Tweet</a> 
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 </p>

--- a/oabutton/apps/bookmarklet/templates/bookmarklet/success.html
+++ b/oabutton/apps/bookmarklet/templates/bookmarklet/success.html
@@ -3,9 +3,14 @@
 <p>Now to find an Open Access version…</p>
 <ul id="oa_links">
 </ul>
-<div>
+<p>
 <a href="http://en.wikipedia.org/wiki/Digital_object_identifier" target="_blank">What's a DOI?</a>
-</div>
+</p>
+<p>
+<a href='https://twitter.com/share?url=http://openaccessbutton.org&text=I hit a #paywall trying to access {{ url }}! Help me demand open access at&via=OA_Button&related=OA_Button' class="twitter-share-button" data-lang="en" data-size="large">Tweet</a> 
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+</p>
+
 {% endblock %}
 {% block scripts %}
 <script src="/static/js/success.js"></script>{% endblock %}

--- a/oabutton/apps/bookmarklet/views.py
+++ b/oabutton/apps/bookmarklet/views.py
@@ -115,7 +115,8 @@ def add_post(req):
 
                 c.update({'scholar_url': scholar_url, 'doi': doi})
 
-            c.update({'oid': str(event.id)})
+            c['oid'] = str(event.id)
+            c['url'] = event.url
 
             return render_to_response('bookmarklet/success.html', c)
         else:


### PR DESCRIPTION
This post was heavily edited 3/11

This should go on page 2 of the bookmarklet form as mentioned in #116 and #118.

For twitter a simple tweet from the users own twitter account is fine. This can take the form of <a href="https://twitter.com/intent/tweet?related=OA_Button&text=I+hit+a+paywall!&url=http%3A%2F%2Foabutton%2Fitems%2F123&via=OA_Button">pre-filled form as suggested by @hubgit below</a>. The code to do this can be found <a href="https://dev.twitter.com/docs/tweet-button">here</a> I think. If possible it would be good for this prefilled text to be taken from the users story - but don't sweat about this. If possible it would be good to have the post automatically tagged with #paywall 

For facebook a "share to timeline" button would be fine. Again if it could take it's default post from the users story that would be nice. If not no worries. If possible it would be good to have the post automatically tagged with #paywall

Can we also have a facebook Like button and a Follow button for twitter on page 2( #118) The Like button should be for the url: https://www.facebook.com/openaccessbutton and the follow button should be for oa_button (example here https://twitter.com/about/resources/buttons#follow)

Summarising. On page 2 it would be good if:
- [x] There was a FB like button
- [x] There was a [twitter follow button](https://dev.twitter.com/docs/follow-button)
- [x] There was the option to [share a users story over a users twitter account](https://dev.twitter.com/docs/tweet-button)
- [x] There was the option to share a users story over facebook with a post to wall
  This ticket merges #19 and #7. 
