### PR TITLE
GET request to http://www.openaccessbutton.org/api/form/page2/ sent over clear HTTP

### DIFF
--- a/oabutton/apps/bookmarklet/templates/bookmarklet/page2.html
+++ b/oabutton/apps/bookmarklet/templates/bookmarklet/page2.html
@@ -48,7 +48,11 @@
 </form>
 {% endblock %}
 {% block scripts %}
+
+{% coment %} Twitter Widget {% endcoment %}
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+
+{% coment %} Facebook Widget {% endcoment %}
 <script>(function(d, s, id) {
   var js, fjs = d.getElementsByTagName(s)[0];
   if (d.getElementById(id)) return;
@@ -56,6 +60,8 @@
   js.src = "//connect.facebook.net/en_US/all.js#xfbml=1&appId=570391483000074";
   fjs.parentNode.insertBefore(js, fjs);
 }(document, 'script', 'facebook-jssdk'));</script>
+
+{% coment %} Google+ Widget {% endcoment %}
 <script type="text/javascript">
   (function() {
     var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;

--- a/oabutton/settings.py
+++ b/oabutton/settings.py
@@ -217,6 +217,10 @@ LOGGING = {
 # Honor the 'X-Forwarded-Proto' header for request.is_secure()
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
+# Send cookies only over HTTPS connections
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
+
 # Bind MongoEngine
 connect('oabutton-server-dev', port=27017)
 

--- a/oabutton/wsgi.py
+++ b/oabutton/wsgi.py
@@ -17,6 +17,9 @@ import os
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "oabutton.settings")
 
+# Enable Django secure mode (see http://security.stackexchange.com/a/8970)
+os.environ["HTTPS"] = "on"
+
 from django.core.wsgi import get_wsgi_application
 
 # This application object is used by any WSGI server configured to use this


### PR DESCRIPTION
Should be HTTPS like the rest of the requests, especially since it contains the CSRF token.
