### PR TITLE
Features/cookieless

### DIFF
--- a/oabutton/apps/bookmarklet/models.py
+++ b/oabutton/apps/bookmarklet/models.py
@@ -42,3 +42,9 @@ class OAUser(models.Model):
         # generate a boilerplate URL for each user
         from django.conf import settings
         return "%s/api/bookmarklet/%s.js" % (settings.HOSTNAME, self.slug)
+
+class OASession(models.Model):
+    key = models.CharField(max_length=40)
+    data = models.TextField()
+    expire = models.FloatField()
+

--- a/oabutton/apps/bookmarklet/templates/bookmarklet/no_user.html
+++ b/oabutton/apps/bookmarklet/templates/bookmarklet/no_user.html
@@ -2,7 +2,7 @@
 {% load oafilters %}
 {% block content %}
 
-<form id="event" action="/api/post/" method="post" class="form-horizontal">{% csrf_token %}
+<form id="event" action="/api/post/" method="post" class="form-horizontal">
 
     <p>Something went wrong.  You'll need to create a new bookmarklet.</p>
 

--- a/oabutton/apps/bookmarklet/templates/bookmarklet/page1.html
+++ b/oabutton/apps/bookmarklet/templates/bookmarklet/page1.html
@@ -2,7 +2,7 @@
 {% load oafilters %}
 {% block content %}
 
-<form id="event" action="/api/post/" method="post" class="form-horizontal">{% csrf_token %}
+<form id="event" action="/api/post/{{key}}/" method="post" class="form-horizontal">
 
   {{ bookmarklet.non_field_errors }}
   {{ bookmarklet.accessed }}

--- a/oabutton/apps/bookmarklet/templates/bookmarklet/page2.html
+++ b/oabutton/apps/bookmarklet/templates/bookmarklet/page2.html
@@ -31,7 +31,7 @@
     </p>
 </div>
 
-<form method="POST" action="{% url 'bookmarklet:form3' %}">{% csrf_token %}
+<form method="POST" action="{% url 'bookmarklet:form3' key=key %}">
 <div class="control-group raleway-font">
     <div class="or-box row-block">
         <div class="row">

--- a/oabutton/apps/bookmarklet/tests.py
+++ b/oabutton/apps/bookmarklet/tests.py
@@ -5,11 +5,11 @@ when you run "manage.py test".
 Replace this with more appropriate tests for your application.
 """
 
+from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.client import Client
 from nose.tools import eq_, ok_
-from oabutton.apps.bookmarklet.models import OAEvent, OAUser
-import datetime
+from oabutton.apps.bookmarklet.models import OAEvent, OAUser, OASession
 import dateutil.parser
 import json
 import re
@@ -58,11 +58,14 @@ class APITest(TestCase):
                      u'slug': self.user.slug, }
 
         c = Client()
-        response = c.post('/api/post/', POST_DATA)
-
+        response = c.get('/api/form/page1/%s/' % self.user.slug)
+        key = response.context['key']
+        response = c.post('/api/post/%s/' % key, POST_DATA)
         assert response.status_code == 302
 
-        evt = OAEvent.objects.get(id=c.session['data']['event_id'])
+        s = OASession.objects.get(key=key)
+        data = json.loads(s.data)
+        evt = OAEvent.objects.get(id=data['event_id'])
 
         expected = {'doi': u'10.1016/j.urology.2010.05.009.',
                     'url': u'http://www.ncbi.nlm.nih.gov/pubmed/20709373',
@@ -88,11 +91,15 @@ class APITest(TestCase):
                      u'slug': self.user.slug, }
 
         c = Client()
-        response = c.post('/api/post/', POST_DATA)
+        response = c.get('/api/form/page1/%s/' % self.user.slug)
+        key = response.context['key']
+        response = c.post('/api/post/%s/' % key, POST_DATA)
 
         assert response.status_code == 302
 
-        evt = OAEvent.objects.get(id=c.session['data']['event_id'])
+        s = OASession.objects.get(key=key)
+        data = json.loads(s.data)
+        evt = OAEvent.objects.get(id=data['event_id'])
 
         expected = {'doi': u'10.1016/j.urology.2010.05.009.',
                     'url': u'http://www.ncbi.nlm.nih.gov/pubmed/20709373',
@@ -120,26 +127,30 @@ class APITest(TestCase):
                      u'slug': user.slug}
 
         c = Client()
-        response = c.post('/api/post/', POST_DATA)
-
+        response = c.get('/api/form/page1/%s/' % self.user.slug)
+        key = response.context['key']
+        response = c.post('/api/post/%s/' % key, POST_DATA)
         assert response.status_code == 302
 
-        data = OAEvent.objects.get(id=c.session['data']['event_id'])
-        eq_(data.coords, {'lat': 44.0, 'lng': -79.5})
-        eq_(data.doi, '10.1016/j.urology.2010.05.009.')
-        eq_(data.url, 'http://www.ncbi.nlm.nih.gov/pubmed/20709373')
+        s = OASession.objects.get(key=key)
+        data = json.loads(s.data)
 
-        actual_date = data.accessed
+        evt = OAEvent.objects.get(id=data['event_id'])
+        eq_(evt.coords, {'lat': 44.0, 'lng': -79.5})
+        eq_(evt.doi, '10.1016/j.urology.2010.05.009.')
+        eq_(evt.url, 'http://www.ncbi.nlm.nih.gov/pubmed/20709373')
+
+        actual_date = evt.accessed
         eq_(actual_date.year, 2013)
         eq_(actual_date.month, 9)
         eq_(actual_date.day, 9)
 
-        eq_(data.user_name, 'some name')
-        eq_(data.user_profession, 'Student')
-        eq_(data.story, 'some access requirement')
+        eq_(evt.user_name, 'some name')
+        eq_(evt.user_profession, 'Student')
+        eq_(evt.story, 'some access requirement')
 
         # Check that we can resolve the original user oid
-        evt = OAEvent.objects.filter(id=c.session['data']['event_id'])[0]
+        evt = OAEvent.objects.filter(id=data['event_id'])[0]
         assert evt.user_slug is not None
 
     def test_update_signon(self):
@@ -182,21 +193,15 @@ class APITest(TestCase):
                      }
 
         c = Client()
-        response = c.post('/api/post/', POST_DATA)
+        response = c.get('/api/form/page1/%s/' % self.user.slug)
+        key = response.context['key']
+        slug = response.context['slug']
 
-        response = c.post('/api/form/page3/')
+        response = c.post('/api/post/%s/' % key, POST_DATA)
+        assert response.status_code == 302
+
+        response = c.post(reverse('bookmarklet:form3', kwargs={'key': key, 'slug': slug}), POST_DATA)
         # Check that the DOI is passed through correctly
         data_doi_re = re.compile('<body [^>]*data-doi="%s">'
                                  % POST_DATA['doi'])
         assert data_doi_re.search(response.content) is not None
-
-    def test_data_xref_proxy(self):
-        # TODO: Need a proper test for this that doesn't clobber the
-        # network. Inject a fake requests mock object into xref_proxy
-        # prior to execution
-        pass
-        """
-        c = Client()
-        response = c.get('/api/xref_proxy/10.1103/PhysRevD.15.2752')
-        assert json.loads(response.content) != None
-        """

--- a/oabutton/apps/bookmarklet/urls.py
+++ b/oabutton/apps/bookmarklet/urls.py
@@ -7,17 +7,17 @@ from views import signin
 from views import xref_proxy
 from views import xref_proxy_simple
 
+
 urlpatterns = patterns('',
                        # I think these 3 should be broken out to an API URL handler so we
                        # can evolve it
-
-                       url(r'^form/page1/(?P<slug>.*)/$', form1, name="form1"),
-                       url(r'^form/page2/$', form2, name="form2"),
-                       url(r'^form/page3/$', form3, name="form3"),
-
-
-                       url(r'^post/$', add_post, name="add_post"),
                        url(r'^signin/$', signin, name="signin"),
+
+                       url(r'^post/(?P<key>.*)/$', add_post, name="add_post"),
+                       url(r'^form/page1/(?P<slug>.*)/$', form1, name="form1"),
+                       url(r'^form/page2/(?P<key>.*)/_slug_(?P<slug>.*)/$', form2, name="form2"),
+                       url(r'^form/page3/(?P<key>.*)/_slug_(?P<slug>.*)/$', form3, name="form3"),
+
                        url(r'^bookmarklet/(?P<slug>.*).js$',
                            generate_bookmarklet,
                            name="generate_bookmarklet"),

--- a/oabutton/apps/web/templates/web/start.jade
+++ b/oabutton/apps/web/templates/web/start.jade
@@ -2,7 +2,6 @@ extends web/index
 - load oafilters
 block start
     form.form-bookmarklet#form-bookmarklet(action='/api/signin/', method='post')
-        {% csrf_token %}
         .row
             .col-md-8.col-md-offset-2
                 p Sign up below to get the 

--- a/oabutton/apps/web/views.py
+++ b/oabutton/apps/web/views.py
@@ -1,6 +1,5 @@
 from django.shortcuts import render_to_response
 from django.conf import settings
-from django.core.context_processors import csrf
 from oabutton.common import SigninForm, teamdata, thanksdata
 import json
 
@@ -9,7 +8,6 @@ def homepage(req):
     # Need to lazy import the OAEvent model so that tests work with
     # mocks
     c = {}
-    c.update(csrf(req))
 
     from oabutton.apps.bookmarklet.models import OAEvent
 

--- a/oabutton/middleware/__init__.py
+++ b/oabutton/middleware/__init__.py
@@ -1,0 +1,1 @@
+from urlsession import FakeSessionCookieMiddleware

--- a/oabutton/middleware/urlsession.py
+++ b/oabutton/middleware/urlsession.py
@@ -1,0 +1,12 @@
+from django.conf import settings as s
+
+
+class FakeSessionCookieMiddleware(object):
+    """
+    This is totally unsafe to use outside of an SSL enviroment.
+    """
+    def process_request(self, req):
+        if not s.SESSION_COOKIE_NAME in req.COOKIES \
+                and s.SESSION_COOKIE_NAME in req.GET:
+            req.COOKIES[s.SESSION_COOKIE_NAME] = \
+                req.GET[s.SESSION_COOKIE_NAME]

--- a/oabutton/settings.py
+++ b/oabutton/settings.py
@@ -1,6 +1,5 @@
 # Django settings for oabutton project.
 
-import sys
 from os.path import dirname, abspath, join
 
 ROOT_PATH = dirname(dirname(abspath(__file__)))
@@ -15,10 +14,11 @@ except IOError:
     VERSION = "unknown"
 
 # Start override vars #
-DEBUG = False #(sys.argv[1] == 'runserver')
+DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 HOSTNAME = 'http://localhost:8000'
 DB_USER = 'postgres'
+DB_HOST = 'localhost'
 # End override vars
 
 try:
@@ -39,7 +39,7 @@ DATABASES = {'default': {
              'USER': DB_USER,    # Not used with sqlite3.
              'PASSWORD': '',                  # Not used with sqlite3.
              # Set to empty string for localhost. Not used with sqlite3.
-             'HOST': '',
+             'HOST': DB_HOST,
              # Set to empty string for default. Not used with sqlite3.
              'PORT': '',
              }}
@@ -121,7 +121,6 @@ COMPRESS_PRECOMPILERS = (
 MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     # Uncomment the next line for simple clickjacking protection:

--- a/oabutton/settings_local.py.example
+++ b/oabutton/settings_local.py.example
@@ -2,6 +2,7 @@ DEBUG = False
 TEMPLATE_DEBUG = DEBUG
 
 DB_USER = 'postgres'
+DB_HOST = ''
 
 # API key for CORE searches
 CORE_API_KEY = "you need this"


### PR DESCRIPTION
Drops cookie requirement from the bookmarklet. I've also removed CSRF because that implicitly requires cookies.

The new session handling code requires that we're running SSL and I expire the session in 10 minutes.

This ought to fix our cookie issue for everyone who doesn't have 3rd party cookies enabled - which will be most people.

cc @kynan @loleg @JosephMcArthur @davidecarroll 
