### PR TITLE
Add Facebook Open Graph meta tags

### DIFF
--- a/oabutton/apps/bookmarklet/templates/bookmarklet/layout.html
+++ b/oabutton/apps/bookmarklet/templates/bookmarklet/layout.html
@@ -4,11 +4,15 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <meta itemprop="name" content="Open Access Button">
-    <meta itemprop="description" content="Paywalls deny people access to life-saving research every day. The Open Access Button will make the damage of paywalls visible to the world and get you access to the research you need.">
-    <meta itemprop="image" content="/static/img/oabutton_logo.png">
+    <meta itemprop="name" property="og:title" property="og:site_name" content="Open Access Button">
+    <meta itemprop="description" property="og:description" content="Paywalls deny people access to life-saving research every day. The Open Access Button will make the damage of paywalls visible to the world and get you access to the research you need.">
+    <meta itemprop="image" property="og:image" content="/static/img/oabutton_logo.png">
+    <meta property="og:url" content="https://openaccessbutton.org">
+    <meta property="og:type" content="website">
+    <meta property="fb:profile_id" content="openaccessbutton">
     <title>Open Access Button</title>
     <link rel="shortcut icon" type="image/x-icon" href="/img/favicon.ico">
+    <link rel="canonical" href="https://openaccessbutton.org">
     <link rel="stylesheet" href="/static/css/bootstrap.min.css">
     <link rel="stylesheet" href="/static/css/font-awesome.min.css">
     <link rel="stylesheet" href="/static/css/social-buttons.css">

--- a/oabutton/apps/web/templates/web/layout.jade
+++ b/oabutton/apps/web/templates/web/layout.jade
@@ -5,15 +5,19 @@ html(lang='en', itemscope, itemtype='http://schema.org/Organization')
     meta(charset='utf-8')
     meta(name='viewport', content='width=device-width, initial-scale=1.0')
     meta(http-equiv='X-UA-Compatible', content='IE=edge,chrome=1')
-    meta(itemprop='name', content='Open Access Button')
-    meta(itemprop='description', content='Paywalls deny people access to life-saving research every day. The Open Access Button will make the damage of paywalls visible to the world and get you access to the research you need.')
-    meta(itemprop='image', content='/static/img/oabutton_logo.png')
+    meta(itemprop='name', property='og:title', content='Open Access Button')
+    meta(itemprop='description', property='og:description', content='Paywalls deny people access to life-saving research every day. The Open Access Button will make the damage of paywalls visible to the world and get you access to the research you need.')
+    meta(itemprop='image', property='og:image', content='/static/img/oabutton_logo.png')
+    meta(property='og:url', content='https://openaccessbutton.org')
+    meta(property='og:type', content='website')
+    meta(property='fb:profile_id', content="openaccessbutton')
     if title
       title Open Access Button - #{title}
     else
       title Open Access Button
     link(rel='shortcut icon', type='image/x-icon', href='/static/img/favicon.ico')
 
+    link(rel='canonical', href='https://openaccessbutton.org')
     link(rel='stylesheet', href='/static/css/bootstrap.min.css')
     link(rel='stylesheet', href='/static/css/leaflet.css') 
     //if lte IE 8


### PR DESCRIPTION
Turn the button into a Facebook "graph" object, allowing a certain
level of customization over how information is carried over from a
non-Facebook website to Facebook when a page is "recommended",
"liked", or just generally shared.
