### PR TITLE
Banner should not obscure map

### DIFF
--- a/oabutton/apps/web/templates/web/index.jade
+++ b/oabutton/apps/web/templates/web/index.jade
@@ -60,14 +60,14 @@ block body
         a(name='world')
         .container
             #map
-                .underlay
-                    .lead
-                        span(id='counter')
-                            {{count|force_escape}}
-                        span 
-                            | Paywalls Hit
-                    p
-                        | This map displays people being denied access to the research they both need and paid for. Put yourself on the map using the Open Access Button to tell the world you are being denied access to knowledge. Using the Open Access Button will make the individual moments of injustice and frustration visible to the world.
+            .underlay
+                .lead
+                    span(id='counter')
+                        {{count|force_escape}}
+                    span 
+                        | Paywalls Hit
+                p
+                    | This map displays people being denied access to the research they both need and paid for. Put yourself on the map using the Open Access Button to tell the world you are being denied access to knowledge. Using the Open Access Button will make the individual moments of injustice and frustration visible to the world.
 
     #intro
         a(name='intro')

--- a/oabutton/settings.py
+++ b/oabutton/settings.py
@@ -19,6 +19,19 @@ TEMPLATE_DEBUG = DEBUG
 HOSTNAME = 'http://localhost:8000'
 DB_USER = 'postgres'
 DB_HOST = 'localhost'
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'oabutton',      # Path to database file.
+        'USER': DB_USER,    # Not used with sqlite3.
+        'PASSWORD': '',                  # Not used with sqlite3.
+        # Set to empty string for localhost. Not used with sqlite3.
+        'HOST': DB_HOST,
+        # Set to empty string for default. Not used with sqlite3.
+        'PORT': '',
+    }
+}
 # End override vars
 
 try:
@@ -32,17 +45,6 @@ ADMINS = (
 )
 
 MANAGERS = ADMINS
-
-DATABASES = {'default': {
-             'ENGINE': 'django.db.backends.postgresql_psycopg2',
-             'NAME': 'oabutton',      # Path to database file.
-             'USER': DB_USER,    # Not used with sqlite3.
-             'PASSWORD': '',                  # Not used with sqlite3.
-             # Set to empty string for localhost. Not used with sqlite3.
-             'HOST': DB_HOST,
-             # Set to empty string for default. Not used with sqlite3.
-             'PORT': '',
-             }}
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 # See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts

--- a/oabutton/static/public/css/styles.css
+++ b/oabutton/static/public/css/styles.css
@@ -1,5 +1,4 @@
 @import "../css/MarkerCluster.css";
-
 @import "../css/MarkerCluster.Default.css";
 /* Don't edit this CSS file.  It's generated using lessc */
 /* Swatches */
@@ -194,7 +193,7 @@ header .lead span {
 /* Activity map */
 #world,
 #map {
-  height: 500px;
+  height: 640px;
   width: 100%;
   margin-top: -20px;
 }
@@ -203,16 +202,17 @@ header .lead span {
   position: absolute;
   left: 0px;
   bottom: 0px;
-  width: 84%;
-  margin: 0 8%;
+  width: 100%;
   padding: 1em 0;
   z-index: 99;
   background: #ffc425;
+  opacity: .75;
 }
 #world .underlay .lead {
   background: #fff;
   text-align: center;
   margin-bottom: 10px;
+  opacity: .875;
 }
 #world .underlay p {
   padding: 0 1em;
@@ -471,7 +471,6 @@ a[data-toggle] {
 }
 .form-bookmarklet {
   /* max-width: 300px; */
-
   padding: 19px 29px 29px;
   margin: 0 auto 20px;
   background-color: #fff;

--- a/oabutton/static/public/css/styles.css
+++ b/oabutton/static/public/css/styles.css
@@ -1,4 +1,5 @@
 @import "../css/MarkerCluster.css";
+
 @import "../css/MarkerCluster.Default.css";
 /* Don't edit this CSS file.  It's generated using lessc */
 /* Swatches */
@@ -167,6 +168,10 @@ header .lead span {
     top: 15px;
   }
 }
+#form-bookmarklet {
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
 #form-bookmarklet .checkbox label {
   font-weight: 700;
 }
@@ -191,32 +196,26 @@ header .lead span {
   filter: alpha(opacity=80);
 }
 /* Activity map */
-#world,
 #map {
-  height: 640px;
+  height: 500px;
   width: 100%;
-  margin-top: -20px;
 }
 #world .underlay {
-  display: none;
-  position: absolute;
-  left: 0px;
-  bottom: 0px;
   width: 100%;
+  margin: 0;
   padding: 1em 0;
   z-index: 99;
   background: #ffc425;
-  opacity: .75;
 }
 #world .underlay .lead {
   background: #fff;
   text-align: center;
   margin-bottom: 10px;
-  opacity: .875;
 }
 #world .underlay p {
-  padding: 0 1em;
   font-size: 110%;
+  padding: 0 12%;
+  margin: 0;
 }
 #counter {
   font-weight: bold;
@@ -471,6 +470,7 @@ a[data-toggle] {
 }
 .form-bookmarklet {
   /* max-width: 300px; */
+
   padding: 19px 29px 29px;
   margin: 0 auto 20px;
   background-color: #fff;

--- a/oabutton/static/public/css/styles.css
+++ b/oabutton/static/public/css/styles.css
@@ -106,6 +106,10 @@ header .lead span {
   border: 1px solid #ddd;
   border-radius: 10px;
 }
+#bookmarklet .btn {
+  background-color: #ef5b23;
+  border-color: #ffc425;
+}
 .slidetop {
   animation-name: swooshlet;
   -o-animation-name: swooshlet;
@@ -174,6 +178,9 @@ header .lead span {
 }
 #form-bookmarklet .checkbox label {
   font-weight: 700;
+}
+#form-bookmarklet .btn-primary {
+  background-color: #008471;
 }
 #help-bookmarklet {
   display: none;
@@ -298,6 +305,7 @@ a[data-toggle] {
   border-color: #444;
   color: #000;
   margin: 0 20px;
+  box-shadow: 3px 3px 10px #a5bfba;
 }
 #contribute {
   background: #fff;
@@ -454,6 +462,9 @@ a[data-toggle] {
     font-size: 15px;
     position: relative;
   }
+  #map {
+    height: 400px;
+  }
 }
 @media screen and (max-width: 520px) {
   header a {
@@ -466,6 +477,9 @@ a[data-toggle] {
   }
   #github_ribbon {
     display: none;
+  }
+  #map {
+    height: 300px;
   }
 }
 .form-bookmarklet {

--- a/oabutton/static/public/less/app.less
+++ b/oabutton/static/public/less/app.less
@@ -126,6 +126,8 @@ header {
 }
 
 #form-bookmarklet {
+  margin-bottom: 0;
+  padding-bottom: 0;
   .checkbox label { font-weight: 700; }
 }
 
@@ -154,31 +156,27 @@ header {
 
 /* Activity map */
 
-#world, #map { 
-  height: 640px;
+#map { 
+  height: 500px; 
   width: 100%; 
-  margin-top: -20px;
 }
 #world {
   .underlay {
-    display: none;
-    position: absolute;
-    left: 0px;
-    bottom: 0px;
     width: 100%;
+    margin: 0;
     padding: 1em 0;
     z-index: 99;
     background: @oayellow;
-    opacity: .75;
-
     .lead {
       background: #fff;
       text-align: center;
       margin-bottom: 10px;
-      opacity: .875;
     }
-
-    p { padding: 0 1em; font-size: 110%; }
+    p { 
+      font-size: 110%;
+      padding: 0 12%; 
+      margin: 0; 
+    }
   }
 }
 

--- a/oabutton/static/public/less/app.less
+++ b/oabutton/static/public/less/app.less
@@ -155,7 +155,7 @@ header {
 /* Activity map */
 
 #world, #map { 
-  height: 500px; 
+  height: 640px;
   width: 100%; 
   margin-top: -20px;
 }
@@ -165,16 +165,17 @@ header {
     position: absolute;
     left: 0px;
     bottom: 0px;
-    width: 84%;
-    margin: 0 8%;
+    width: 100%;
     padding: 1em 0;
     z-index: 99;
     background: @oayellow;
+    opacity: .75;
 
     .lead {
       background: #fff;
       text-align: center;
       margin-bottom: 10px;
+      opacity: .875;
     }
 
     p { padding: 0 1em; font-size: 110%; }

--- a/oabutton/static/public/less/app.less
+++ b/oabutton/static/public/less/app.less
@@ -99,6 +99,10 @@ header {
   background: white;
   border: 1px solid #ddd;
   border-radius: 10px;
+  .btn {
+    background-color: @oaorange;
+    border-color: @oayellow;
+  }
 }
 
 .slidetop {
@@ -129,6 +133,7 @@ header {
   margin-bottom: 0;
   padding-bottom: 0;
   .checkbox label { font-weight: 700; }
+  .btn-primary { background-color: @oagreen2; }
 }
 
 #help-bookmarklet {
@@ -254,6 +259,7 @@ a[data-toggle] {
     border-color: #444;
     color: #000;
     margin: 0 20px;
+    box-shadow: 3px 3px 10px @oagreys2;
   }
 }
 
@@ -394,7 +400,9 @@ a[data-toggle] {
   body { padding-top: 0px; }
   header a { background-size:100%; }
   header .lead { font-size:15px; position:relative; }
+  #map { height: 400px; }
 }
+
 @media screen and (max-width: 520px) {
   header a { 
     height: 110px; position: absolute; 
@@ -402,4 +410,5 @@ a[data-toggle] {
   }
   header .lead { visibility: hidden; }
   #github_ribbon { display: none; }
+  #map { height: 300px; }
 }


### PR DESCRIPTION
Currently, the banner at
https://www.openaccessbutton.org/#world
obscures large parts of the southern hemisphere when viewed at the default resolution. 
Please move away, preferably such that it does not overlap with map or at least can be moved around or clicked away easily.
