### PR TITLE
Make Travis CI run existing qunit tests using PhantomJS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ install: pip install -r requirements.txt --use-mirrors
 script:
   #- "flake8"
   - "python manage.py test web bookmarklet metadata"
+  - "phantomjs scripts/qunit-runner.js oabutton/static/test/test.html"
 before_script:
 before_script:
   - psql -c 'create database oabutton;' -U postgres

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -7,6 +7,8 @@
  * [mongodb](http://docs.mongodb.org/manual/installation/)
  * [virtualenv](https://pypi.python.org/pypi/virtualenv) (optional but
    recommended)
+ * [PhantomJS](http://phantomjs.org/) (required to run automated
+   Javascript tests)
 
 ### Installing
 
@@ -89,9 +91,20 @@ run from a Makefile. Install Node.js then `npm install lessc -g`, then run
 
 ### Running the tests
 
-From the directory with the file manage.py in it
+From the directory with the file manage.py in it, run the Python tests
+with:
 ```
 python manage.py test bookmarklet web
+```
+
+Run the JavaScript tests with:
+```
+phantomjs scripts/qunit-runner.js oabutton/static/test/test.html
+```
+
+If you have `make` installed, you can also just run:
+```
+make test
 ```
 
 ### Heroku deployment

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test lessc
+.PHONY: test test_js test_py lessc
 
 all: build
 
@@ -8,5 +8,10 @@ lessc:
 	lessc oabutton/static/public/less/styles.less oabutton/static/public/css/styles.css
 
 
-test:
+test: test_js test_py
+
+test_py:
 	python manage.py test web bookmarklet metadata
+
+test_js:
+	phantomjs scripts/qunit-runner.js oabutton/static/test/test.html

--- a/oabutton/static/test/test.html
+++ b/oabutton/static/test/test.html
@@ -9,7 +9,7 @@
       <div id="qunit"></div>
       <div id="qunit-fixture"></div>
       <script src="resources/qunit.js"></script>
-      <script src="../public/js/jquery.min.js"></script>
+      <script src="../public/js/lib/jquery.min.js"></script>
       <script src="resources/jquery.mockjax.js"></script>
       <script src="../public/js/success.js"></script>
       <script src="test.js"></script>

--- a/oabutton/static/test/test.js
+++ b/oabutton/static/test/test.js
@@ -21,7 +21,7 @@ test( "parseCrossRef", function() {
 
 test( "addScholarDOILink", function() {
   var $fixture = $('#qunit-fixture');
-  $fixture.append('<ul id="oa_links"></ul>');
+  $fixture.append('<ul id="google_links"></ul>');
 
   oabSuccess.addScholarDOILink(this.metadata);
 
@@ -33,7 +33,7 @@ test( "addScholarDOILink", function() {
 
 test( "addScholarTitleLink", function() {
   var $fixture = $('#qunit-fixture');
-  $fixture.append('<ul id="oa_links"></ul>');
+  $fixture.append('<ul id="google_links"></ul>');
 
   oabSuccess.addScholarTitleLink(this.metadata);
 
@@ -47,7 +47,7 @@ asyncTest( "discoverCORELinks", function() {
   expect(3);
 
   var $fixture = $('#qunit-fixture');
-  $fixture.append('<ul id="oa_links"></ul>');
+  $fixture.append('<ul id="core_links"></ul>');
 
   $.mockjax({
     url: "/metadata/coresearch.json/*",
@@ -57,7 +57,7 @@ asyncTest( "discoverCORELinks", function() {
   oabSuccess.discoverCORELinks(this.metadata);
 
   setTimeout(function() {
-    var link = $("a", $fixture);
+    var link = $("li a", $fixture);
     equal(link.length, 3, "Three links added");
 
     link = $("a:contains('Jaccoud\u2019s Arthritis')", $fixture);

--- a/scripts/qunit-runner.js
+++ b/scripts/qunit-runner.js
@@ -1,0 +1,139 @@
+/*
+ * QtWebKit-powered headless test runner using PhantomJS
+ *
+ * PhantomJS binaries: http://phantomjs.org/download.html
+ * Requires PhantomJS 1.6+ (1.7+ recommended)
+ *
+ * Run with:
+ *   phantomjs runner.js [url-of-your-qunit-testsuite]
+ *
+ * e.g.
+ *   phantomjs runner.js http://localhost/qunit/test/index.html
+ */
+
+/*global phantom:false, require:false, console:false, window:false, QUnit:false */
+
+(function() {
+	'use strict';
+
+	var url, page, timeout,
+		args = require('system').args;
+
+	// arg[0]: scriptName, args[1...]: arguments
+	if (args.length < 2 || args.length > 3) {
+		console.error('Usage:\n  phantomjs runner.js [url-of-your-qunit-testsuite] [timeout-in-seconds]');
+		phantom.exit(1);
+	}
+
+	url = args[1];
+	page = require('webpage').create();
+	if (args[2] !== undefined) {
+		timeout = parseInt(args[2], 10);
+	}
+
+	// Route `console.log()` calls from within the Page context to the main Phantom context (i.e. current `this`)
+	page.onConsoleMessage = function(msg) {
+		console.log(msg);
+	};
+
+	page.onInitialized = function() {
+		page.evaluate(addLogging);
+	};
+
+	page.onCallback = function(message) {
+		var result,
+			failed;
+
+		if (message) {
+			if (message.name === 'QUnit.done') {
+				result = message.data;
+				failed = !result || result.failed;
+
+				phantom.exit(failed ? 1 : 0);
+			}
+		}
+	};
+
+	page.open(url, function(status) {
+		if (status !== 'success') {
+			console.error('Unable to access network: ' + status);
+			phantom.exit(1);
+		} else {
+			// Cannot do this verification with the 'DOMContentLoaded' handler because it
+			// will be too late to attach it if a page does not have any script tags.
+			var qunitMissing = page.evaluate(function() { return (typeof QUnit === 'undefined' || !QUnit); });
+			if (qunitMissing) {
+				console.error('The `QUnit` object is not present on this page.');
+				phantom.exit(1);
+			}
+
+			// Set a timeout on the test running, otherwise tests with async problems will hang forever
+			if (typeof timeout === 'number') {
+				setTimeout(function() {
+					console.error('The specified timeout of ' + timeout + ' seconds has expired. Aborting...');
+					phantom.exit(1);
+				}, timeout * 1000);
+			}
+
+			// Do nothing... the callback mechanism will handle everything!
+		}
+	});
+
+	function addLogging() {
+		window.document.addEventListener('DOMContentLoaded', function() {
+			var currentTestAssertions = [];
+
+			QUnit.log(function(details) {
+				var response;
+
+				// Ignore passing assertions
+				if (details.result) {
+					return;
+				}
+
+				response = details.message || '';
+
+				if (typeof details.expected !== 'undefined') {
+					if (response) {
+						response += ', ';
+					}
+
+					response += 'expected: ' + details.expected + ', but was: ' + details.actual;
+				}
+
+				if (details.source) {
+					response += "\n" + details.source;
+				}
+
+				currentTestAssertions.push('Failed assertion: ' + response);
+			});
+
+			QUnit.testDone(function(result) {
+				var i,
+					len,
+					name = result.module + ': ' + result.name;
+
+				if (result.failed) {
+					console.log('Test failed: ' + name);
+
+					for (i = 0, len = currentTestAssertions.length; i < len; i++) {
+						console.log('    ' + currentTestAssertions[i]);
+					}
+				}
+
+				currentTestAssertions.length = 0;
+			});
+
+			QUnit.done(function(result) {
+				console.log('Took ' + result.runtime +  'ms to run ' + result.total + ' tests. ' + result.passed + ' passed, ' + result.failed + ' failed.');
+
+				if (typeof window.callPhantom === 'function') {
+					window.callPhantom({
+						'name': 'QUnit.done',
+						'data': result
+					});
+				}
+			});
+		}, false);
+	}
+})();


### PR DESCRIPTION
No new tests added, but Travis now runs the existing tests for success.js (and they pass!). Also try:

```
$ phantomjs scripts/qunit-runner.js oabutton/static/test/test.html
```

Should address #194 — now to fill out the test suite as per #152.
