### PR TITLE
Generally improve display of CORE hits

### DIFF
--- a/oabutton/static/public/js/success.js
+++ b/oabutton/static/public/js/success.js
@@ -140,18 +140,24 @@ var oabSuccess = (function($) {
 	  if (total_hits > 0) {
             var $list = $('<ul></ul>');
             for (var i = 1; i < records.length; i++) {
-              metadata = records[i]['record']['metadata']['oai_dc:dc'];
+              record = records[i]['record']['metadata']['oai_dc:dc'];
               $list.append('<li><a target="_blank" href="'
-                           + metadata['dc:identifier']
+                           + record['dc:identifier']
                            + '">'
-                           + formatAuthorList(parseAuthorList(metadata['dc:creator']))
-                           + ' (' + metadata['dc:date'] + '); '
-                           + metadata['dc:title']
+                           + formatAuthorList(parseAuthorList(record['dc:creator']))
+                           + ' (' + record['dc:date'] + '); '
+                           + record['dc:title']
                            + '</a></li>');
             }
 
+	    $list.append($('<li><a target="_blank" href="http://core.kmi.open.ac.uk/search/'
+			   + encodeURIComponent('title:(' + metadata['title'] + ')')
+			   + '">See all results'
+			   + '</a></li>'));
+
             $core_div  = $('<div id="core_results">' + total_hits + ' matches from the <a href="http://core.kmi.open.ac.uk/">CORE</a> repository:</div>');
             $core_div.append($list);
+
             $("#core_links").append($core_div);
 	  } else { // no hits
 	    var $core_div = $('<div id="core_results">No matches from the <a href="http://core.kmi.open.ac.uk/">CORE</a> repository.</div>');

--- a/oabutton/static/public/js/success.js
+++ b/oabutton/static/public/js/success.js
@@ -124,21 +124,28 @@ var oabSuccess = (function($) {
         dataType: 'json',
         success: function(response) {
           var records = response.ListRecords;
-          var $list = $('<ul></ul>');
-          for (var i = 1; i < records.length; i++) {
-            metadata = records[i]['record']['metadata']['oai_dc:dc'];
-            $list.append('<li><a target="_blank" href="'
-                         + metadata['dc:identifier']
-                         + '">'
-                         + metadata['dc:creator']
-                         + ' (' + metadata['dc:date'] + '); '
-                         + metadata['dc:title']
-                         + '</a></li>');
-          }
+	  var total_hits = records[0].total_hits;
 
-          $core_div  = $('<div id="core_results">Matches from the <a href="http://core.kmi.open.ac.uk/">CORE</a> repository:</div>');
-          $core_div.append($list);
-          $("#core_links").append($core_div);
+	  if (total_hits > 0) {
+            var $list = $('<ul></ul>');
+            for (var i = 1; i < records.length; i++) {
+              metadata = records[i]['record']['metadata']['oai_dc:dc'];
+              $list.append('<li><a target="_blank" href="'
+                           + metadata['dc:identifier']
+                           + '">'
+                           + metadata['dc:creator']
+                           + ' (' + metadata['dc:date'] + '); '
+                           + metadata['dc:title']
+                           + '</a></li>');
+            }
+
+            $core_div  = $('<div id="core_results">' + total_hits + ' matches from the <a href="http://core.kmi.open.ac.uk/">CORE</a> repository:</div>');
+            $core_div.append($list);
+            $("#core_links").append($core_div);
+	  } else { // no hits
+	    var $core_div = $('<div id="core_results">No matches from the <a href="http://core.kmi.open.ac.uk/">CORE</a> repository.</div>');
+	    $("#core_links").append($core_div);
+	  }
         }
       });
     }

--- a/oabutton/static/public/js/success.js
+++ b/oabutton/static/public/js/success.js
@@ -14,7 +14,7 @@ var oabSuccess = (function($) {
         item["dc:creator"] = [item["dc:creator"]];
       }
 
-      metadata["authors"] = item["dc:creator"].join(", ");
+      metadata["authors"] = formatAuthorList(item["dc:creator"]);
     }
 
     if (item["prism:publicationName"]) {
@@ -27,6 +27,17 @@ var oabSuccess = (function($) {
     }
 
     return metadata;
+  }
+
+  function formatAuthorList(author_list) {
+    if (author_list.length <= 2)
+      return author_list.join(" & ");
+    else
+      return author_list[0] + " et. al.";
+  }
+
+  function parseAuthorList(author_list) {
+    return author_list.split(/\s*[,&]\s*|\s+and\s+/);
   }
 
   function lookupCrossRef() {
@@ -133,7 +144,7 @@ var oabSuccess = (function($) {
               $list.append('<li><a target="_blank" href="'
                            + metadata['dc:identifier']
                            + '">'
-                           + metadata['dc:creator']
+                           + formatAuthorList(parseAuthorList(metadata['dc:creator']))
                            + ' (' + metadata['dc:date'] + '); '
                            + metadata['dc:title']
                            + '</a></li>');
@@ -153,6 +164,8 @@ var oabSuccess = (function($) {
 
   return {
     parseCrossRef: parseCrossRef,
+    formatAuthorList: formatAuthorList,
+    parseAuthorList: parseAuthorList,
     lookupCrossRef: lookupCrossRef,
     addScholarDOILink: addScholarDOILink,
     addScholarTitleLink: addScholarTitleLink,

--- a/oabutton/static/public/js/success.js
+++ b/oabutton/static/public/js/success.js
@@ -135,9 +135,9 @@ var oabSuccess = (function($) {
         dataType: 'json',
         success: function(response) {
           var records = response.ListRecords;
-	  var total_hits = records[0].total_hits;
+          var total_hits = records[0].total_hits;
 
-	  if (total_hits > 0) {
+          if (total_hits > 0) {
             var $list = $('<ul></ul>');
             for (var i = 1; i < records.length; i++) {
               record = records[i]['record']['metadata']['oai_dc:dc'];
@@ -150,19 +150,19 @@ var oabSuccess = (function($) {
                            + '</a></li>');
             }
 
-	    $list.append($('<li><a target="_blank" href="http://core.kmi.open.ac.uk/search/'
-			   + encodeURIComponent('title:(' + metadata['title'] + ')')
-			   + '">See all results'
-			   + '</a></li>'));
+            $list.append($('<li><a target="_blank" href="http://core.kmi.open.ac.uk/search/'
+                           + encodeURIComponent('title:(' + metadata['title'] + ')')
+                           + '">See all results'
+                           + '</a></li>'));
 
             $core_div  = $('<div id="core_results">' + total_hits + ' matches from the <a href="http://core.kmi.open.ac.uk/">CORE</a> repository:</div>');
             $core_div.append($list);
 
             $("#core_links").append($core_div);
-	  } else { // no hits
-	    var $core_div = $('<div id="core_results">No matches from the <a href="http://core.kmi.open.ac.uk/">CORE</a> repository.</div>');
-	    $("#core_links").append($core_div);
-	  }
+          } else { // no hits
+            var $core_div = $('<div id="core_results">No matches from the <a href="http://core.kmi.open.ac.uk/">CORE</a> repository.</div>');
+            $("#core_links").append($core_div);
+          }
         }
       });
     }

--- a/oabutton/static/public/js/success.js
+++ b/oabutton/static/public/js/success.js
@@ -119,28 +119,28 @@ var oabSuccess = (function($) {
     var title = metadata["title"];
 
     if (title) {
-        $.ajax({
-            url: "/metadata/coresearch.json/title:(" + encodeURIComponent(title) + ")",
-            dataType: 'json',
-            success: function(response) {
-                var records = response.ListRecords;
-                var $list = $('<ul></ul>');
-                for (var i = 1; i < records.length; i++) {
-                    metadata = records[i]['record']['metadata']['oai_dc:dc'];
-                    $list.append('<li><a target="_blank" href="'
-                        + metadata['dc:identifier']
-                        + '">'
-                        + metadata['dc:creator']
-                        + ' (' + metadata['dc:date'] + '); '
-                        + metadata['dc:title']
-                        + '</a></li>');
-                }
+      $.ajax({
+        url: "/metadata/coresearch.json/title:(" + encodeURIComponent(title) + ")",
+        dataType: 'json',
+        success: function(response) {
+          var records = response.ListRecords;
+          var $list = $('<ul></ul>');
+          for (var i = 1; i < records.length; i++) {
+            metadata = records[i]['record']['metadata']['oai_dc:dc'];
+            $list.append('<li><a target="_blank" href="'
+                         + metadata['dc:identifier']
+                         + '">'
+                         + metadata['dc:creator']
+                         + ' (' + metadata['dc:date'] + '); '
+                         + metadata['dc:title']
+                         + '</a></li>');
+          }
 
-                $core_div  = $('<div id="core_results">Matches from the <a href="http://core.kmi.open.ac.uk/">CORE</a> repository:</div>');
-                $core_div.append($list);
-                $("#core_links").append($core_div);
-            }
-        });
+          $core_div  = $('<div id="core_results">Matches from the <a href="http://core.kmi.open.ac.uk/">CORE</a> repository:</div>');
+          $core_div.append($list);
+          $("#core_links").append($core_div);
+        }
+      });
     }
   }
 

--- a/oabutton/static/test/test.js
+++ b/oabutton/static/test/test.js
@@ -83,7 +83,7 @@ test( "addScholarTitleLink", function() {
 });
 
 asyncTest( "discoverCORELinks", function() {
-  expect(4);
+  expect(6);
 
   var $fixture = $('#qunit-fixture');
   $fixture.append('<ul id="core_links"></ul>');
@@ -94,18 +94,25 @@ asyncTest( "discoverCORELinks", function() {
   });
 
   oabSuccess.discoverCORELinks(this.metadata);
+  metadata = this.metadata;
 
   setTimeout(function() {
-    var link = $("li a", $fixture);
-    equal(link.length, 3, "Three links added");
+    var $link = $("li a", $fixture);
+    equal($link.length, 4, "Four links added"); // 3 + 1 "full search" link
 
     var $core_div = $('#core_links', $fixture);
     ok(/5015 matches/.test($core_div.text()), "Number of hits shown");
 
-    link = $("a:contains('Jaccoud\u2019s Arthritis')", $fixture);
-    equal(link.length, 1, "Link with 'Jaccoud\u2019s Arthritis' added");
-    equal(link.attr('href'), "http:\/\/www.jkscience.org\/archive\/111\/18-RL-JACORD%20ARTHRITIS.pdf",
-	  "Link points to correct PDF");
+    $link = $("a:contains('Jaccoud\u2019s Arthritis')", $fixture);
+    equal($link.length, 1, "Link with 'Jaccoud\u2019s Arthritis' added");
+    equal($link.attr('href'), "http:\/\/www.jkscience.org\/archive\/111\/18-RL-JACORD%20ARTHRITIS.pdf",
+    	  "Link points to correct PDF");
+
+    $link = $("a:contains('See all results')", $fixture);
+    equal($link.length, 1, "'See all results' link");
+    equal($link.attr('href'),
+    	  "http://core.kmi.open.ac.uk/search/" + encodeURIComponent("title:(" + metadata.title + ")"),
+    	  "Link points to correct PDF");
 
     start();
   }, 500);

--- a/oabutton/static/test/test.js
+++ b/oabutton/static/test/test.js
@@ -9,6 +9,9 @@ module("success.js", {
       date: "2013-4-9",
     };
   },
+  teardown: function() {
+    $.mockjaxClear();
+  },
 });
 
 test( "parseCrossRef", function() {
@@ -44,7 +47,7 @@ test( "addScholarTitleLink", function() {
 });
 
 asyncTest( "discoverCORELinks", function() {
-  expect(3);
+  expect(4);
 
   var $fixture = $('#qunit-fixture');
   $fixture.append('<ul id="core_links"></ul>');
@@ -60,6 +63,9 @@ asyncTest( "discoverCORELinks", function() {
     var link = $("li a", $fixture);
     equal(link.length, 3, "Three links added");
 
+    var $core_div = $('#core_links', $fixture);
+    ok(/5015 matches/.test($core_div.text()), "Number of hits shown");
+
     link = $("a:contains('Jaccoud\u2019s Arthritis')", $fixture);
     equal(link.length, 1, "Link with 'Jaccoud\u2019s Arthritis' added");
     equal(link.attr('href'), "http:\/\/www.jkscience.org\/archive\/111\/18-RL-JACORD%20ARTHRITIS.pdf",
@@ -68,3 +74,28 @@ asyncTest( "discoverCORELinks", function() {
     start();
   }, 500);
 });
+
+asyncTest( "discoverCORELinks empty result set", function() {
+  expect(2);
+
+  var $fixture = $('#qunit-fixture');
+  $fixture.append('<ul id="core_links"></ul>');
+
+  $.mockjax({
+    url: "/metadata/coresearch.json/*",
+    responseText: {"ListRecords":[{"total_hits":0}]}
+  });
+
+  oabSuccess.discoverCORELinks(this.metadata);
+
+  setTimeout(function() {
+    var $link = $("li a", $fixture);
+    equal($link.length, 0, "No links added");
+
+    var $core_div = $('#core_links', $fixture);
+    ok(/No matches/.test($core_div.text()), "Useful error shown");
+
+    start();
+  }, 500);
+});
+

--- a/oabutton/static/test/test.js
+++ b/oabutton/static/test/test.js
@@ -28,34 +28,34 @@ test( "formatAuthorList", function() {
   three_authors = ["A. N. Other", "J. Smith", "F. Jones"];
 
   equal(oabSuccess.formatAuthorList(one_author),
-	"A. N. Other", "Single author");
+        "A. N. Other", "Single author");
   equal(oabSuccess.formatAuthorList(two_authors),
-	"A. N. Other & J. Smith", "Two authors");
+        "A. N. Other & J. Smith", "Two authors");
   equal(oabSuccess.formatAuthorList(three_authors),
-	"A. N. Other et. al.", "Three or more authors");
+        "A. N. Other et. al.", "Three or more authors");
 });
 
 test( "parseAuthorList", function() {
   deepEqual(oabSuccess.parseAuthorList("A. N. Other"),
-	["A. N. Other"], "Single author");
+        ["A. N. Other"], "Single author");
   deepEqual(oabSuccess.parseAuthorList("A. N. Other and J. Smith"),
-	["A. N. Other", "J. Smith"],
-	"Two authors with 'and'");
+        ["A. N. Other", "J. Smith"],
+        "Two authors with 'and'");
   deepEqual(oabSuccess.parseAuthorList("A. N. Other, J. Smith"),
-	["A. N. Other", "J. Smith"],
-	"Two authors with comma");
+        ["A. N. Other", "J. Smith"],
+        "Two authors with comma");
   deepEqual(oabSuccess.parseAuthorList("A. N. Other & J. Smith"),
-	["A. N. Other", "J. Smith"],
-	"Two authors with ampersand");
+        ["A. N. Other", "J. Smith"],
+        "Two authors with ampersand");
   deepEqual(oabSuccess.parseAuthorList("A. N. Other, F. Jones and J. Smith"),
-	["A. N. Other", "F. Jones", "J. Smith"],
-	"Three authors with comma and 'and'");
+        ["A. N. Other", "F. Jones", "J. Smith"],
+        "Three authors with comma and 'and'");
   deepEqual(oabSuccess.parseAuthorList("A. N. Other and F. Jones and J. Smith"),
-	["A. N. Other", "F. Jones", "J. Smith"],
-	"Three authors with 'and'");
+        ["A. N. Other", "F. Jones", "J. Smith"],
+        "Three authors with 'and'");
   deepEqual(oabSuccess.parseAuthorList("A. N. Other, F. Jones, J. Smith"),
-	["A. N. Other", "F. Jones", "J. Smith"],
-	"Three authors with commas");
+        ["A. N. Other", "F. Jones", "J. Smith"],
+        "Three authors with commas");
 });
 
 test( "addScholarDOILink", function() {
@@ -106,13 +106,13 @@ asyncTest( "discoverCORELinks", function() {
     $link = $("a:contains('Jaccoud\u2019s Arthritis')", $fixture);
     equal($link.length, 1, "Link with 'Jaccoud\u2019s Arthritis' added");
     equal($link.attr('href'), "http:\/\/www.jkscience.org\/archive\/111\/18-RL-JACORD%20ARTHRITIS.pdf",
-    	  "Link points to correct PDF");
+          "Link points to correct PDF");
 
     $link = $("a:contains('See all results')", $fixture);
     equal($link.length, 1, "'See all results' link");
     equal($link.attr('href'),
-    	  "http://core.kmi.open.ac.uk/search/" + encodeURIComponent("title:(" + metadata.title + ")"),
-    	  "Link points to correct PDF");
+          "http://core.kmi.open.ac.uk/search/" + encodeURIComponent("title:(" + metadata.title + ")"),
+          "Link points to correct PDF");
 
     start();
   }, 500);

--- a/oabutton/static/test/test.js
+++ b/oabutton/static/test/test.js
@@ -22,6 +22,42 @@ test( "parseCrossRef", function() {
   deepEqual(result, this.metadata, "Parses data correctly");
 });
 
+test( "formatAuthorList", function() {
+  one_author = ["A. N. Other"];
+  two_authors = ["A. N. Other", "J. Smith"];
+  three_authors = ["A. N. Other", "J. Smith", "F. Jones"];
+
+  equal(oabSuccess.formatAuthorList(one_author),
+	"A. N. Other", "Single author");
+  equal(oabSuccess.formatAuthorList(two_authors),
+	"A. N. Other & J. Smith", "Two authors");
+  equal(oabSuccess.formatAuthorList(three_authors),
+	"A. N. Other et. al.", "Three or more authors");
+});
+
+test( "parseAuthorList", function() {
+  deepEqual(oabSuccess.parseAuthorList("A. N. Other"),
+	["A. N. Other"], "Single author");
+  deepEqual(oabSuccess.parseAuthorList("A. N. Other and J. Smith"),
+	["A. N. Other", "J. Smith"],
+	"Two authors with 'and'");
+  deepEqual(oabSuccess.parseAuthorList("A. N. Other, J. Smith"),
+	["A. N. Other", "J. Smith"],
+	"Two authors with comma");
+  deepEqual(oabSuccess.parseAuthorList("A. N. Other & J. Smith"),
+	["A. N. Other", "J. Smith"],
+	"Two authors with ampersand");
+  deepEqual(oabSuccess.parseAuthorList("A. N. Other, F. Jones and J. Smith"),
+	["A. N. Other", "F. Jones", "J. Smith"],
+	"Three authors with comma and 'and'");
+  deepEqual(oabSuccess.parseAuthorList("A. N. Other and F. Jones and J. Smith"),
+	["A. N. Other", "F. Jones", "J. Smith"],
+	"Three authors with 'and'");
+  deepEqual(oabSuccess.parseAuthorList("A. N. Other, F. Jones, J. Smith"),
+	["A. N. Other", "F. Jones", "J. Smith"],
+	"Three authors with commas");
+});
+
 test( "addScholarDOILink", function() {
   var $fixture = $('#qunit-fixture');
   $fixture.append('<ul id="google_links"></ul>');


### PR DESCRIPTION
- Show the total number of hits available in CORE (or "No matches" if none — fixes #167)
- Link to show all results
- Truncate the author lists with _et. al._ if they get too long

Are we happy with the formatting of the link text for CORE hits?
