### PR TITLE
Features/227 author submit oa

### DIFF
--- a/oabutton/apps/bookmarklet/email_tools.py
+++ b/oabutton/apps/bookmarklet/email_tools.py
@@ -11,13 +11,6 @@ def send_author_notification(author_email, blocked_url):
     Send the author of a paper notification that his paper was
     blocked. Request for an open link.
     """
-    blocked_filter = OABlockedURL.objects.filter(blocked_url=blocked_url,
-                                                 author_email=author_email)
-    if blocked_filter.count() != 0:
-        # Skip any email notifications if this author has already been
-        # notified about this URL
-        return
-
     md5hash = hashlib.md5(author_email + blocked_url + time.asctime())
     slug = md5hash.hexdigest()
     record = OABlockedURL.objects.create(slug=slug,

--- a/oabutton/apps/bookmarklet/email_tools.py
+++ b/oabutton/apps/bookmarklet/email_tools.py
@@ -10,14 +10,17 @@ def send_author_notification(author_email, blocked_url):
     Send the author of a paper notification that his paper was
     blocked. Request for an open link.
     """
-    md5hash = hashlib.md5(author_email + blocked_url + time.asctime())
-    slug = md5hash.hexdigest()
     blocked_filter = OABlockedURL.objects.filter(blocked_url=blocked_url,
                                                  author_email=author_email)
     if blocked_filter.count() != 0:
         # Skip any email notifications if this author has already been
         # notified about this URL
         return
+
+    # TODO: extract author_email here using PhantomJS
+
+    md5hash = hashlib.md5(author_email + blocked_url + time.asctime())
+    slug = md5hash.hexdigest()
     record = OABlockedURL.objects.create(slug=slug,
                                          author_email=author_email,
                                          blocked_url=blocked_url)

--- a/oabutton/apps/bookmarklet/email_tools.py
+++ b/oabutton/apps/bookmarklet/email_tools.py
@@ -32,3 +32,10 @@ def send_author_notification(author_email, blocked_url):
                           context=context,
                           to=[author_email])
     email.send()
+
+
+def check_paper(url, slug, created):
+    """
+    This method checks that the
+    """
+    pass

--- a/oabutton/apps/bookmarklet/email_tools.py
+++ b/oabutton/apps/bookmarklet/email_tools.py
@@ -36,6 +36,8 @@ def send_author_notification(author_email, blocked_url):
 
 def check_paper(url, slug, created):
     """
-    This method checks that the
+    This method checks that the url is readable.
+
+    For now, just ping it with a requests call.
     """
-    pass
+    raise NotImplementedError

--- a/oabutton/apps/bookmarklet/fixtures/foo.html
+++ b/oabutton/apps/bookmarklet/fixtures/foo.html
@@ -1,5 +1,0 @@
-<html>
-    <body>
-        hello world
-    </body>
-</html>

--- a/oabutton/apps/bookmarklet/migrations/0008_auto__add_invalidoalink.py
+++ b/oabutton/apps/bookmarklet/migrations/0008_auto__add_invalidoalink.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'InvalidOALink'
+        db.create_table(u'bookmarklet_invalidoalink', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('src', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['bookmarklet.OABlockedURL'])),
+            ('url', self.gf('django.db.models.fields.URLField')(max_length=2000)),
+        ))
+        db.send_create_signal(u'bookmarklet', ['InvalidOALink'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'InvalidOALink'
+        db.delete_table(u'bookmarklet_invalidoalink')
+
+
+    models = {
+        u'bookmarklet.invalidoalink': {
+            'Meta': {'object_name': 'InvalidOALink'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'src': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['bookmarklet.OABlockedURL']"}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '2000'})
+        },
+        u'bookmarklet.oablockedurl': {
+            'Meta': {'object_name': 'OABlockedURL'},
+            'author_email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'db_index': 'True'}),
+            'blocked_url': ('django.db.models.fields.URLField', [], {'max_length': '2000', 'db_index': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'auto_now': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'open_url': ('django.db.models.fields.URLField', [], {'max_length': '2000', 'db_index': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '40', 'db_index': 'True'})
+        },
+        u'bookmarklet.oaevent': {
+            'Meta': {'object_name': 'OAEvent'},
+            'accessed': ('django.db.models.fields.DateTimeField', [], {}),
+            'coords_lat': ('django.db.models.fields.FloatField', [], {}),
+            'coords_lng': ('django.db.models.fields.FloatField', [], {}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'doi': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'location': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'story': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '2000', 'db_index': 'True'}),
+            'user_email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'user_name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'user_profession': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'user_slug': ('django.db.models.fields.CharField', [], {'max_length': '40', 'db_index': 'True'})
+        },
+        u'bookmarklet.oasession': {
+            'Meta': {'object_name': 'OASession'},
+            'data': ('django.db.models.fields.TextField', [], {}),
+            'expire': ('django.db.models.fields.FloatField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '40'})
+        },
+        u'bookmarklet.oauser': {
+            'Meta': {'object_name': 'OAUser'},
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'db_index': 'True'}),
+            'email_confirmed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mailinglist': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'profession': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'salt': ('django.db.models.fields.CharField', [], {'max_length': '12', 'null': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40'})
+        }
+    }
+
+    complete_apps = ['bookmarklet']

--- a/oabutton/apps/bookmarklet/models.py
+++ b/oabutton/apps/bookmarklet/models.py
@@ -115,7 +115,7 @@ class OABlockedURL(models.Model):
 def best_open_url(blocked_url):
     cursor = connection.cursor()
     try:
-        rset = cursor.execute("""
+        cursor.execute("""
         select count(open_url) open_count, open_url from
         bookmarklet_oablockedurl where blocked_url = %s group by open_url order by open_count desc
         """, [blocked_url])

--- a/oabutton/apps/bookmarklet/models.py
+++ b/oabutton/apps/bookmarklet/models.py
@@ -65,6 +65,7 @@ class OAUser(models.Model):
 
         email = TemplateEmail(template='bookmarklet/email_confirmation.html',
                               context=context,
+                              from_email=settings.OABUTTON_EMAIL,
                               to=[self.email])
         email.send()
 

--- a/oabutton/apps/bookmarklet/templates/bookmarklet/open_document.jade
+++ b/oabutton/apps/bookmarklet/templates/bookmarklet/open_document.jade
@@ -35,22 +35,24 @@ block body
     #intro
         a(name='intro')
         .container
-            h2 Thanks!  Lets add a link to an open access version of your document to our repository!
-            .row.hilite-left
-                .col-md-12
-                    p
-                        {{ form.slug }}
-                        if form.errors.author_email
-                            {{ form.errors.author_email }}
-                        {{ form.author_email }}
-                    p
-                        if form.errors.blocked_url
-                            {{ form.errors.blocked_url }}
-                        {{ form.blocked_url }}
-                    p
-                        if form.errors.open_url
-                            {{ form.errors.open_url }}
-                        {{ form.open_url }}
+            h2 Thanks!
+            h3 Lets add a link to an open access version of your document to our repository!
+            form.form-bookmarklet(action='/api/api/v1/open_document/{{ slug }}', method='post')
+                .row
+                    .col-md-12
+                        p
+                            {{ form.slug }}
+                            label E-mail address with article
+                            {{ form.author_email }}
+                        p
+                            label Paywall Article URL
+                            {{ form.blocked_url }}
+                        p
+                            label URL to an Open Access version of article
+                            {{ form.open_url }}
+                        p
+                          button.btn.btn-lg.btn-primary.btn-block(type='submit')
+                            | Submit open access version of document
 
 
     #footer

--- a/oabutton/apps/bookmarklet/templates/bookmarklet/open_document_success.jade
+++ b/oabutton/apps/bookmarklet/templates/bookmarklet/open_document_success.jade
@@ -31,15 +31,11 @@ block body
     #start
         .container.center
             block start
-    
+
     #intro
         a(name='intro')
         .container
-            h2 Thanks!  Lets add a link to an open access version of your document to our repository!
-            .row.hilite-left
-                .col-md-12
-                    p.link-added
-                        | Thanks!  Your link has been added to our database.
+            h2 Your link has been added to our database! 
 
     #footer
         a(name='contact')

--- a/oabutton/apps/bookmarklet/templates/bookmarklet/open_document_unreachable.jade
+++ b/oabutton/apps/bookmarklet/templates/bookmarklet/open_document_unreachable.jade
@@ -38,8 +38,9 @@ block body
             h2 Thanks!  Lets add a link to an open access version of your document to our repository!
             .row.hilite-left
                 .col-md-12
-                    p.link-added
-                        | Thanks!  Your link has been added to our database.
+                    p.link-unreachable
+                        | The link you submitted was not reachable from the public intenret. Error: {{ error }}
+                        | We'll try to help you out
 
     #footer
         a(name='contact')

--- a/oabutton/apps/bookmarklet/templates/bookmarklet/open_document_unreachable.jade
+++ b/oabutton/apps/bookmarklet/templates/bookmarklet/open_document_unreachable.jade
@@ -35,12 +35,10 @@ block body
     #intro
         a(name='intro')
         .container
-            h2 Thanks!  Lets add a link to an open access version of your document to our repository!
-            .row.hilite-left
-                .col-md-12
-                    p.link-unreachable
-                        | The link you submitted was not reachable from the public intenret. Error: {{ error }}
-                        | We'll try to help you out
+            h3 The link you submitted was not reachable from the public internet.
+            a(href='/api/api/v1/open_document/{{slug}}')
+                button.btn.btn-lg.btn-primary.btn-block(type='submit')
+                    | Try Again
 
     #footer
         a(name='contact')

--- a/oabutton/apps/bookmarklet/templates/bookmarklet/page2.html
+++ b/oabutton/apps/bookmarklet/templates/bookmarklet/page2.html
@@ -41,10 +41,6 @@
         </div>
     </div>
 </div>
-
-
-
-
 </form>
 {% endblock %}
 {% block scripts %}

--- a/oabutton/apps/bookmarklet/templates/bookmarklet/page3.html
+++ b/oabutton/apps/bookmarklet/templates/bookmarklet/page3.html
@@ -28,17 +28,21 @@
             <h4>Email a request for the paper directly to the author</h4>
             <p>
                 We've detected the following email addresses - if these
-                appear to be the author, please click the button to
-                request an open access version.
+                appear to be the author, please check off the
+                addresses you wish to notify and click the "Notify
+                Authors" button to request an open access version.
             </p>
-            {% for contact_email in possible_emails %}
-            <div class="row">
-                <div class="col-md-12 row-block">
-                    <button class="btn btn-primary btn-block">Ask {{ contact_email }}</button>
+            <form method="POST" action="{% url 'bookmarklet:notify_authors' key=key slug=slug %}">
+                {% for contact_email in possible_emails %}
+                <div class="row">
+                    <div class="col-md-12 row-block">
+                        <input type="checkbox" name="notify_authors" value="{{contact_email}}">Ask {{ contact_email }}
+                    </div>
                 </div>
-            </div>
-            <br />
-            {% endfor %}
+                <br />
+                {% endfor %}
+                <button class="btn btn-primary btn-block">Notify Authors</button>
+            </form>
         </div>
         <hr />
     {% endif %}

--- a/oabutton/apps/bookmarklet/templates/bookmarklet/page3.html
+++ b/oabutton/apps/bookmarklet/templates/bookmarklet/page3.html
@@ -8,6 +8,7 @@
     You can go here : {{ open_url }}
     {% endif %}
 
+
     <p>Below are a number of ways to get access to your paper, unfortunately
     they won't always work but it's worth a shot.
     </p>
@@ -22,21 +23,25 @@
 
     <hr />
 
-    {% comment %}
-
-    // Disabling this for now as we don't have a robust email scraping
-    // service
-    <div id="email-request" class="row-block">
-        <h4>Email a request for the paper directly to the author</h4>
-        <div class="row">
-            <div class="col-md-12 row-block">
-                <button class="btn btn-primary btn-block">Ask [addres@goes.here]</button>
+    {% if possible_emails %}
+        <div id="email-request" class="row-block">
+            <h4>Email a request for the paper directly to the author</h4>
+            <p>
+                We've detected the following email addresses - if these
+                appear to be the author, please click the button to
+                request an open access version.
+            </p>
+            {% for contact_email in possible_emails %}
+            <div class="row">
+                <div class="col-md-12 row-block">
+                    <button class="btn btn-primary btn-block">Ask {{ contact_email }}</button>
+                </div>
             </div>
+            <br />
+            {% endfor %}
         </div>
-    </div>
-    <hr />
-
-    {% endcomment %}
+        <hr />
+    {% endif %}
 
     <div>
         <h4>Searching for related documents</h4>

--- a/oabutton/apps/bookmarklet/templates/bookmarklet/page3.html
+++ b/oabutton/apps/bookmarklet/templates/bookmarklet/page3.html
@@ -1,6 +1,13 @@
 {% extends "bookmarklet/layout.html" %}{% block content %}
 <div class="raleway-font">
     <h2>Thanks!</h2>
+
+    {% if open_url %}
+    We've found an open access version of your link.
+    <p>
+    You can go here : {{ open_url }}
+    {% endif %}
+
     <p>Below are a number of ways to get access to your paper, unfortunately
     they won't always work but it's worth a shot.
     </p>

--- a/oabutton/apps/bookmarklet/templates/bookmarklet/page4.html
+++ b/oabutton/apps/bookmarklet/templates/bookmarklet/page4.html
@@ -1,0 +1,8 @@
+{% extends "bookmarklet/layout.html" %}{% block content %}
+<div class="raleway-font">
+    <h2>Thanks! Authors have been notified</h2>
+{% endblock %}
+{% block scripts %}
+<script src="/static/js/success.js"></script>
+{% endblock %}
+{% block body_attrs %}data-doi="{{doi|urlencode}}"{% endblock %}

--- a/oabutton/apps/bookmarklet/templates/bookmarklet/request_open_version.html
+++ b/oabutton/apps/bookmarklet/templates/bookmarklet/request_open_version.html
@@ -18,18 +18,28 @@ The Open Access Button
 {% endbody %}
 
 {% bodyhtml %}
+<p>
 Someone using the Open Access Button has recently hit a paywall on the
 article at <a href="{{ blocked_url }}">{{ blocked_url }}</a> that you
 are listed as a corresponding author on.
+</p>
 
+<p>
 You can submit a link to a freely available version of your article by
 using:
+</p>
 
+<p>
 <a href="{{ oa_free_url }}">{{ oa_free_url }}</a>
+</p>
 
+<p>
 The system will automatically inform all people who have requested
 your article that a freely available copy is available.
+</p>
 
-Best Wishes,
+<p>
+Best Wishes, <br />
 The Open Access Button
+</p>
 {% endbodyhtml %}

--- a/oabutton/apps/bookmarklet/tests.py
+++ b/oabutton/apps/bookmarklet/tests.py
@@ -20,12 +20,8 @@ from oabutton.apps.bookmarklet.email_tools import send_author_notification
 from oabutton.apps.bookmarklet.models import OAEvent, OAUser, OASession
 from oabutton.apps.bookmarklet.models import OABlockedURL
 
-from os.path import split, join
 
-
-# TODO: replace this and use mock to do the right thing with http urls
-FIXTURE_PATH = join(split(__file__)[0], 'fixtures')
-MOCK_URL = "file://" + join(FIXTURE_PATH, 'foo.html')
+MOCK_URL = "http://this.is.mocked.by.mock/foo/"
 
 
 class MockGET(object):
@@ -191,7 +187,7 @@ class APITest(TestCase):
         response = c.post('/api/signin/', self.POST_DATA)
 
         eq_(response.status_code, 200)
-        # Extract the slug frmo the javascript URL
+        # Extract the slug from the javascript URL
         new_slug = json.loads(response.content)['url'][-35:-3]
 
         # check that we have all the signin fields

--- a/oabutton/apps/bookmarklet/tests.py
+++ b/oabutton/apps/bookmarklet/tests.py
@@ -288,10 +288,6 @@ class APITest(TestCase):
         assert url in msg.body
         mail.outbox = []
 
-        # Check that we never notify the author twice
-        send_author_notification(author_email, blocked_url)
-        self.assertEqual(len(mail.outbox), 0)
-
     @mock.patch('requests.get', mock.Mock(side_effect=[MockGET(404)]))
     def test_add_oa_document_404(self):
         '''

--- a/oabutton/apps/bookmarklet/tests.py
+++ b/oabutton/apps/bookmarklet/tests.py
@@ -14,6 +14,8 @@ import dateutil.parser
 import json
 import re
 
+import mock
+
 from oabutton.apps.bookmarklet.email_tools import send_author_notification
 from oabutton.apps.bookmarklet.models import OAEvent, OAUser, OASession
 from oabutton.apps.bookmarklet.models import OABlockedURL
@@ -23,6 +25,10 @@ from os.path import split, join
 
 FIXTURE_PATH = join(split(__file__)[0], 'fixtures')
 MOCK_URL = "file://" + join(FIXTURE_PATH, 'foo.html')
+
+
+class MockGET200(object):
+    status_code = 200
 
 
 class APITest(TestCase):
@@ -285,6 +291,7 @@ class APITest(TestCase):
         send_author_notification(author_email, blocked_url)
         self.assertEqual(len(mail.outbox), 0)
 
+    @mock.patch('requests.get', mock.Mock(side_effect=[MockGET200()]))
     def test_add_oa_document(self):
         '''
         Add a link to an open access version of the document

--- a/oabutton/apps/bookmarklet/tests.py
+++ b/oabutton/apps/bookmarklet/tests.py
@@ -353,31 +353,6 @@ class APITest(TestCase):
 
         self.assertTrue("Your link has been added" in response.content)
 
-    def test_add_oa_document_errors(self):
-        # First send the author an email notification
-        author_email, blocked_url = 'test@test.com', MOCK_URL
-        open_url = 'http://some.open.com/some/url/'
-        send_author_notification(author_email, blocked_url)
-
-        blocked = list(OABlockedURL.objects.all())
-        obj = blocked[0]
-        slug = obj.slug
-        c = Client()
-        response = c.get(reverse('bookmarklet:open_document', kwargs={'slug': slug}))
-        eq_(response.status_code, 200)
-
-        assert author_email in response.content
-        assert blocked_url in response.content
-
-        post_data = {'author_email': author_email,
-                     'open_url': open_url,
-                     'slug': slug}
-
-        response = c.post(reverse('bookmarklet:open_document', kwargs={'slug': slug}), post_data)
-        eq_(response.status_code, 200)
-        content = response.content
-        assert 'This field is required' in content
-
     def test_most_common_blocked_url_results(self):
         """
         Create a bunch of blocked URL objects for the same url with

--- a/oabutton/apps/bookmarklet/tests.py
+++ b/oabutton/apps/bookmarklet/tests.py
@@ -198,6 +198,8 @@ class APITest(TestCase):
         eq_(user.profession, 'Student')
         ok_(user.mailinglist)
 
+    @mock.patch('oabutton.phantomjs.email_extractor.scrape_email', mock.Mock(return_value=('mock@mock.com',)))
+    @mock.patch('requests.get', mock.Mock(side_effect=[MockGET(200)]))
     def test_search_doi_after_post(self):
         '''
         Tests to make sure the response to submitting the form is rendered

--- a/oabutton/apps/bookmarklet/urls.py
+++ b/oabutton/apps/bookmarklet/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import patterns, url
 
-from views import form1, form2, form3, notify_authors
+from views import form1, form2, form3, form4, notify_authors
 from views import add_post
 from views import generate_bookmarklet
 from views import signin
@@ -17,6 +17,7 @@ urlpatterns = patterns('',
                        url(r'^form/page1/(?P<slug>.*)/$', form1, name="form1"),
                        url(r'^form/page2/(?P<key>.*)/_slug_(?P<slug>.*)/$', form2, name="form2"),
                        url(r'^form/page3/(?P<key>.*)/_slug_(?P<slug>.*)/$', form3, name="form3"),
+                       url(r'^form/page4/$', form4, name="form4"),
                        url(r'^form/notify_authors/(?P<key>.*)/_slug_(?P<slug>.*)/$', notify_authors, name="notify_authors"),
 
                        url(r'^confirmation/(?P<slug>.*)_(?P<salt>.*)/$',

--- a/oabutton/apps/bookmarklet/urls.py
+++ b/oabutton/apps/bookmarklet/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import patterns, url
 
-from views import form1, form2, form3
+from views import form1, form2, form3, notify_authors
 from views import add_post
 from views import generate_bookmarklet
 from views import signin
@@ -17,6 +17,7 @@ urlpatterns = patterns('',
                        url(r'^form/page1/(?P<slug>.*)/$', form1, name="form1"),
                        url(r'^form/page2/(?P<key>.*)/_slug_(?P<slug>.*)/$', form2, name="form2"),
                        url(r'^form/page3/(?P<key>.*)/_slug_(?P<slug>.*)/$', form3, name="form3"),
+                       url(r'^form/notify_authors/(?P<key>.*)/_slug_(?P<slug>.*)/$', notify_authors, name="notify_authors"),
 
                        url(r'^confirmation/(?P<slug>.*)_(?P<salt>.*)/$',
                            email_confirm,

--- a/oabutton/apps/bookmarklet/views.py
+++ b/oabutton/apps/bookmarklet/views.py
@@ -249,8 +249,13 @@ def open_document(req, slug):
                 obj = blocked_urls[0]
                 obj.open_url = data['open_url']
                 obj.save()
-                obj.check_oa_url()
-                return render_to_response('bookmarklet/open_document_success.jade')
+                ok, error = obj.check_oa_url()
+
+                if ok:
+                    return render_to_response('bookmarklet/open_document_success.jade')
+                else:
+                    return render_to_response('bookmarklet/open_document_unreachable.jade',
+                                              {'error': str(error)})
             else:
                 # the slug doesn't exist, inform the user
                 return render_to_response('bookmarklet/open_document_no_slug.jade')

--- a/oabutton/apps/bookmarklet/views.py
+++ b/oabutton/apps/bookmarklet/views.py
@@ -13,6 +13,7 @@ import requests
 import uuid
 import datetime
 from oabutton.apps.bookmarklet.forms import OpenAccessForm
+from oabutton.apps.bookmarklet.models import best_open_url
 
 
 @csrf_exempt
@@ -141,6 +142,8 @@ def form3(req, key, slug):
 
     c = {}
     c.update({'scholar_url': scholar_url, 'doi': doi, 'url': event.url})
+
+    c.update({'open_url': best_open_url(event.url)})
     return render_to_response('bookmarklet/page3.html', c,
                               context_instance=RequestContext(req))
 

--- a/oabutton/apps/bookmarklet/views.py
+++ b/oabutton/apps/bookmarklet/views.py
@@ -236,6 +236,10 @@ def email_confirm(req, slug, salt):
 
 @csrf_exempt
 def open_document(req, slug):
+    """
+    TODO: figure out how to resolve multiple submissions in the case
+    that an open_url is already registered
+    """
     if req.method == 'POST':
         form = OpenAccessForm(req.POST)  # A form bound to the POST data
         if form.is_valid():  # All validation rules pass
@@ -245,6 +249,7 @@ def open_document(req, slug):
                 obj = blocked_urls[0]
                 obj.open_url = data['open_url']
                 obj.save()
+                obj.check_oa_url()
                 return render_to_response('bookmarklet/open_document_success.jade')
             else:
                 # the slug doesn't exist, inform the user

--- a/oabutton/apps/bookmarklet/views.py
+++ b/oabutton/apps/bookmarklet/views.py
@@ -239,10 +239,6 @@ def email_confirm(req, slug, salt):
 
 @csrf_exempt
 def open_document(req, slug):
-    """
-    TODO: figure out how to resolve multiple submissions in the case
-    that an open_url is already registered
-    """
     if req.method == 'POST':
         form = OpenAccessForm(req.POST)  # A form bound to the POST data
         if form.is_valid():  # All validation rules pass

--- a/oabutton/apps/bookmarklet/views.py
+++ b/oabutton/apps/bookmarklet/views.py
@@ -14,6 +14,7 @@ import uuid
 import datetime
 from oabutton.apps.bookmarklet.forms import OpenAccessForm
 from oabutton.apps.bookmarklet.models import best_open_url
+from oabutton.phantomjs.email_extractor import scrape_email
 
 
 @csrf_exempt
@@ -144,6 +145,10 @@ def form3(req, key, slug):
     c.update({'scholar_url': scholar_url, 'doi': doi, 'url': event.url})
 
     c.update({'open_url': best_open_url(event.url)})
+
+    possible_emails = tuple(scrape_email(event.url))
+    c.update({"possible_emails": possible_emails})
+
     return render_to_response('bookmarklet/page3.html', c,
                               context_instance=RequestContext(req))
 

--- a/oabutton/apps/web/tests.py
+++ b/oabutton/apps/web/tests.py
@@ -13,9 +13,6 @@ from nose.tools import eq_, ok_
 from oabutton.apps.bookmarklet.models import OAEvent
 import BeautifulSoup
 
-# TODO: tests should probably use real database data as the views
-# actually load from disk and render to JSON. Remove these mocks.
-
 # This sets up a mock for the OAEvent class
 all_objs = MagicMock()
 all_objs.to_json.return_value = [MagicMock(), MagicMock()]

--- a/oabutton/phantomjs/email_extractor.py
+++ b/oabutton/phantomjs/email_extractor.py
@@ -67,7 +67,7 @@ def scrape_email(url, domain=None):
                 msg = "Networking Error status_code=[%s] error=[%s]" % (status_code, error)
                 raise RuntimeError(msg)
 
-        possible_emails = [f[0] for f in re.findall(r'([a-z0-9_\.\-\+]+@[a-z0-9_\-]+(\.[a-z0-9_\-]+)*)', stdoutdata, re.I)]
+        possible_emails = [f[0] for f in re.findall(r'([a-z0-9_\.\-\+]+@[a-z0-9_\-]+(\.[a-z0-9_\-]+)+)', stdoutdata, re.I)]
         if filter_domain:
             possible_emails = [f for f in possible_emails if not f.endswith(domain)]
 

--- a/oabutton/phantomjs/email_extractor.py
+++ b/oabutton/phantomjs/email_extractor.py
@@ -73,5 +73,13 @@ def scrape_email(url, domain=None):
 
         possible_emails = set([e.lower() for e in possible_emails])
 
+        # Filter out any emails that have already been sent to this
+        # URL
+        for email in list(possible_emails):
+            from oabutton.apps.bookmarklet.models import OABlockedURL
+            block_filter = OABlockedURL.objects.filter(blocked_url=url, author_email=email)
+            if block_filter.count():
+                possible_emails.remove(email)
+
         return possible_emails
     return set()

--- a/oabutton/phantomjs/email_extractor.py
+++ b/oabutton/phantomjs/email_extractor.py
@@ -65,12 +65,12 @@ def scrape_email(url, domain=None):
             if 'success' not in [m.strip() for m in split_msg[:10]]:
                 error = split_msg[1:]
                 msg = "Networking Error status_code=[%s] error=[%s]" % (status_code, error)
-                raise RuntimeError, msg
+                raise RuntimeError(msg)
 
-        possible_emails = [f[0] for f in re.findall(r'([a-z0-9_\-\+]+@[a-z0-9_\-]+(\.[a-z0-9_\-]+))',
-                stdoutdata)]
+        possible_emails = [f[0] for f in re.findall(r'([a-z0-9_\-\+]+@[a-z0-9_\-]+(\.[a-z0-9_\-]+))', stdoutdata)]
         if filter_domain:
             possible_emails = [f for f in possible_emails if not f.endswith(domain)]
+
         possible_emails = set(possible_emails)
 
         return possible_emails

--- a/oabutton/phantomjs/email_extractor.py
+++ b/oabutton/phantomjs/email_extractor.py
@@ -67,11 +67,11 @@ def scrape_email(url, domain=None):
                 msg = "Networking Error status_code=[%s] error=[%s]" % (status_code, error)
                 raise RuntimeError(msg)
 
-        possible_emails = [f[0] for f in re.findall(r'([a-z0-9_\-\+]+@[a-z0-9_\-]+(\.[a-z0-9_\-]+))', stdoutdata)]
+        possible_emails = [f[0] for f in re.findall(r'([a-z0-9_\.\-\+]+@[a-z0-9_\-]+(\.[a-z0-9_\-]+))', stdoutdata, re.I)]
         if filter_domain:
             possible_emails = [f for f in possible_emails if not f.endswith(domain)]
 
-        possible_emails = set(possible_emails)
+        possible_emails = set([e.lower() for e in possible_emails])
 
         return possible_emails
     return set()

--- a/oabutton/phantomjs/email_extractor.py
+++ b/oabutton/phantomjs/email_extractor.py
@@ -67,7 +67,7 @@ def scrape_email(url, domain=None):
                 msg = "Networking Error status_code=[%s] error=[%s]" % (status_code, error)
                 raise RuntimeError(msg)
 
-        possible_emails = [f[0] for f in re.findall(r'([a-z0-9_\.\-\+]+@[a-z0-9_\-]+(\.[a-z0-9_\-]+))', stdoutdata, re.I)]
+        possible_emails = [f[0] for f in re.findall(r'([a-z0-9_\.\-\+]+@[a-z0-9_\-]+(\.[a-z0-9_\-]+)*)', stdoutdata, re.I)]
         if filter_domain:
             possible_emails = [f for f in possible_emails if not f.endswith(domain)]
 

--- a/oabutton/phantomjs/fixtures/sciencemag.html
+++ b/oabutton/phantomjs/fixtures/sciencemag.html
@@ -252,7 +252,6 @@ div.referrer-based-search-line .collection-name{
 
 <!------ OAS SETUP begin ------>
 <!-- Include OAS Analytics Setup Script -->
-<SCRIPT LANGUAGE="JavaScript" src="http://oascentral.sciencemag.org/Scripts/oas_analytics.js"></SCRIPT>
 <SCRIPT LANGUAGE=JavaScript>
 <!--
 //configuration
@@ -261,6 +260,8 @@ OAS_sitepage = window.location.hostname + window.location.pathname;
 OAS_listpos = 'Top,Left1,Right1,Right2';
 var OAS_query ='tw_country_code=CA&view=abstract';
 var OAS_taxonomy = '';
+var OAS_CA = '';
+var OAS_rdl = '';
 OAS_query += '&XE' + '&' + OAS_taxonomy + OAS_rdl + "&if_nt_CookieAccept=" + OAS_CA + '&XE';
 //Jeff_test = 'recent_issue=false';
 OAS_target = '_top';
@@ -268,10 +269,6 @@ OAS_target = '_top';
 OAS_version = 10;
 OAS_rn = '001234567890'; OAS_rns = '1234567890';
 OAS_rn = new String (Math.random()); OAS_rns = OAS_rn.substring (2, 11);
-function OAS_NORMAL(pos) {
-document.write('<A HREF="' + OAS_url + 'click_nx.ads/' + OAS_sitepage + '/1' + OAS_rns + '@' + OAS_listpos + '!' + pos + '?' + OAS_query + '" TARGET=' + OAS_target + '>');
-document.write('<IMG SRC="' + OAS_url + 'adstream_nx.ads/' + OAS_sitepage + '/1' + OAS_rns + '@' + OAS_listpos + '!' + pos + '?' + OAS_query + '" BORDER=0></A>');
-}
  //-->
  </SCRIPT>
 <SCRIPT LANGUAGE=JavaScript1.1>
@@ -285,10 +282,6 @@ document.write('<SCR' + 'IPT LANGUAGE=JavaScript1.1 SRC="' + OAS_url + 'adstream
 <!--
  document.write('');
 function OAS_AD(pos) {
-if (OAS_version >= 11)
- OAS_RICH(pos);
-else
- OAS_NORMAL(pos);
 }  //-->
  </SCRIPT>
 <!------ OAS SETUP end ------>

--- a/oabutton/phantomjs/fixtures/springerlink.html
+++ b/oabutton/phantomjs/fixtures/springerlink.html
@@ -1,0 +1,1412 @@
+<!DOCTYPE html>
+<!--[if lt IE 7]> <html lang="en" class="no-js ie6 lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 7]>    <html lang="en" class="no-js ie7 lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>    <html lang="en" class="no-js ie8 lt-ie9"> <![endif]-->
+<!--[if IE 9]>    <html lang="en" class="no-js ie9"> <![endif]-->
+<!--[if gt IE 9]><!--> <html lang="en" class="no-js"> <!--<![endif]-->
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="description" content=""/>
+  <meta name="author" content=""/>
+  <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"/>
+  <meta name="format-detection" content="telephone=no"/>
+  <meta name="citation_publisher" content="Springer Netherlands"/>
+  <meta name="citation_title" content="Exercise and Nervous System"/>
+  <meta name="citation_firstpage" content="299"/>
+  <meta name="citation_lastpage" content="318"/>
+  <meta name="citation_doi" content="10.1007/978-1-4020-8716-5_14"/>
+  <meta name="citation_language" content="en"/>
+  <meta name="citation_abstract_html_url" content="http://link.springer.com/chapter/10.1007/978-1-4020-8716-5_14"/>
+  <meta name="citation_pdf_url" content="http://link.springer.com/content/pdf/10.1007%2F978-1-4020-8716-5_14.pdf"/>
+  <meta name="citation_springer_api_url" content="http://api.springer.com/metadata/pam?q=doi:10.1007/978-1-4020-8716-5_14&amp;api_key="/>
+  <meta name="citation_author" content="Kazuhiro Imai"/>
+  <meta name="citation_author_institution" content="Yokohama Sports Medical Center, Nissan Stadium, 3302-5, Kotsukue-cho, Kohoku-ku"/>
+  <meta name="citation_author_email" content="imaik-ort@umin.ac.jp"/>
+  <meta name="citation_author" content="Hiroyuki Nakajima"/>
+  <meta name="citation_inbook_title" content="Mechanosensitivity of the Nervous System"/>
+  <meta name="citation_isbn" content="978-1-4020-8715-8"/>
+  <meta name="citation_isbn" content="978-1-4020-8716-5"/>
+  <meta name="citation_publication_date" content="2009/01/01"/>
+  <!--[if (gt IE 8) | (IEMobile)]><!--> <link rel="stylesheet" media="screen" href="/static/0.7947/css/modern_link.min.css"> <!--<![endif]-->
+  <!--[if (lt IE 9) & (!IEMobile)]> <link rel="stylesheet" media="screen" href="/static/0.7947/css/ielt9_link.min.css"> <![endif]-->
+  <link rel="stylesheet" media="print" href="/static/0.7947/css/print.css"/>
+  <link rel="apple-touch-icon-precomposed" size="144x144" href="/static/0.7947/sites/link/images/apple-touch-icon-144x144-precomposed.png"/>
+  <link rel="apple-touch-icon-precomposed" size="114x114" href="/static/0.7947/sites/link/images/apple-touch-icon-114x114-precomposed.png"/>
+  <link rel="apple-touch-icon-precomposed" size="72x72" href="/static/0.7947/sites/link/images/apple-touch-icon-72x72-precomposed.png"/>
+  <link rel="apple-touch-icon-precomposed" size="57x57" href="/static/0.7947/sites/link/images/apple-touch-icon-57x57-precomposed.png"/>
+  <link rel="apple-touch-icon-precomposed" href="/static/0.7947/sites/link/images/apple-touch-icon-57x57-precomposed.png"/>
+  <link rel="shortcut icon" href="/static/0.7947/sites/link/images/favicon-32x32.png"/>
+  <!--[if IE]>
+    <link rel="shortcut icon" href="/static/0.7947/sites/link/images/favicon.ico"/>
+  <![endif]-->
+  <meta name="msapplication-TileColor" content="#FFFFFF"/>
+  <meta name="msapplication-TileImage" content="/static/0.7947/sites/link/images/ms-tileimage.png"/>
+  <link rel="canonical" href="http://link.springer.com/chapter/10.1007%2F978-1-4020-8716-5_14"/>
+  <script type="text/javascript">window.jsErrors = [];window.onerror = function(errorMessage) {window.jsErrors[window.jsErrors.length] = errorMessage;}</script>
+  <script>document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/,'js');</script>
+  <script type="text/javascript">
+    var googletag = googletag || {};
+    googletag.cmd = googletag.cmd || [];
+    (function() {
+    var gads = document.createElement('script');
+    gads.async = true;
+    gads.type = 'text/javascript';
+    var useSSL = 'https:' == document.location.protocol;
+    gads.src = (useSSL ? 'https:' : 'http:') +
+    '//www.googletagservices.com/tag/js/gpt.js';
+    var node = document.getElementsByTagName('script')[0];
+    node.parentNode.insertBefore(gads, node);
+    })();
+  </script>
+  <script type="text/javascript" id="googletag-push">
+    googletag.cmd.push(function() {
+    googletag.defineSlot('6313/casper/book/chapter', [160, 600], 'doubleclick-ad').addService(googletag.pubads());
+    googletag.pubads().setTargeting("eisbn","978-1-4020-8716-5");
+    googletag.pubads().setTargeting("pisbn","978-1-4020-8715-8");
+    googletag.pubads().setTargeting("doi","10.1007-978-1-4020-8716-5_14");
+    googletag.pubads().setTargeting("sucode",["SUCO11642"]);
+    googletag.pubads().setTargeting("pmc",["L","L14005","B18006","H36001","L16008","H2903X"]);
+    googletag.pubads().setTargeting("BPID",["1"]);
+    googletag.pubads().enableSingleRequest();
+    googletag.enableServices();
+    });
+  </script>
+  <title>Exercise and Nervous System - Springer</title>
+</head>
+
+<body class="anonymous link" data-name="link">
+  <div id="wrapper">
+    <div id="header" role="banner">
+  <h1>
+  <a id="logo" href="/">
+    <img src="/static/0.7947/sites/link/images/logo-base.png" alt="Logo Springer" title="SpringerLink"/>
+  </a>
+</h1>
+
+  <div class="panel-search">
+    <form id="global-search" class="big-search" action="/search" method="get" role="search">
+      <div class="search-field">
+        <input id="query" class="text" name="query" type="text" autocomplete="off" value="" placeholder="Search" title="Search"/>
+      </div>
+      <input id="search" class="search-submit" type="submit" value="Submit" title="New Search"/>
+      <div id="search-options" class="flyout">
+        <button class="pillow-btn open-search-options" title="Open search options" type="button">Search Options</button>
+        <div class="flyout-content">
+          <ul>
+            <li>
+              <a id="advanced-search-link" href="/advanced-search">Advanced Search</a>
+            </li>
+            <li>
+              <a id="search-help-link" href="/searchhelp">Search Help</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </form>
+  </div>
+  <button class="pillow-btn open-search" title="Open search">Search</button>
+  <button class="pillow-btn open-menu" title="Open menu">Menu</button>
+  <div class="panel-menu">
+    <div id="cross-nav">
+      <div id="auth" class="flyout">
+        <button class="flyout-caption">Sign up / Log in</button>
+        <div class="flyout-content">
+          <ul>
+            <li>
+              <a id="register-link" class="action" href="/signup-login?previousUrl=%2Fchapter%2F10.1007%252F978-1-4020-8716-5_14">Sign up / Log in</a>
+              <a id="institutional-link" class="action" href="/institutional-login?previousUrl=%2Fchapter%2F10.1007%252F978-1-4020-8716-5_14">Institutional / Athens login</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div id="lang" class="flyout">
+        <button class="flyout-caption cur">English</button>
+        <div class="flyout-content">
+          <ul>
+            <li>
+              <a id="change-language-Deutsch" href="/language/Deutsch" rel="nofollow">Deutsch</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div id="edition" class="flyout">
+  <button class="flyout-caption cur">Academic edition</button>
+  <div class="flyout-content">
+    <ul>
+      <li>
+        <a class="edition-select" href="/siteEdition/rd" rel="nofollow">Corporate edition</a>
+      </li>
+    </ul>
+  </div>
+</div>
+
+    </div>
+    <!-- /- giving kb-only user the option to skip to relevant content (see KeyboardNavigation.js) -->
+    <div id="skip-navigation">
+      <p class="skip-navigation--label">
+        <span>Skip to:</span>
+        <a href="#kb-nav--main">Main content</a>
+        <a href="#kb-nav--aside">Side column</a>
+      </p>
+    </div>
+    <div id="logo-company">
+    </div>
+    <ul id="global-nav" class="clearfix" role="navigation">
+      <li>
+        <a href="/">Home</a>
+      </li>
+      <li>
+        <a href="/contactus">Contact Us</a>
+      </li>
+    </ul>
+  </div>
+</div>
+
+    <div id="content">
+      <input id="autoShowLookInside" type="hidden" value="false"/>
+      <div id="chapter" class="document no-access" itemscope="itemscope" itemtype="http://schema.org/ScholarlyArticle">
+        <div class="bar-dock">
+      <div class="bar-wrapper">
+        <div class="bar-actions">
+          <span class="action icon-view">
+            <a class="lookinside-href webtrekk-track pdf-link" href="/chapter/10.1007%2F978-1-4020-8716-5_14/lookinside/000.png" title="Look Inside" pageType="rd_springer_com.book.chapter_preview" doi="10.1007/978-1-4020-8716-5_14" parentDoi="10.1007/978-1-4020-8716-5" parentContentType="Book" contentType="Chapter" publication="10.1007/978-1-4020-8716-5 | Mechanosensitivity of the Nervous System" viewType="Preview">Look Inside</a>
+          </span>
+          <span class="action icon-unlock">
+            <a class="access-link webtrekk-track" href="/accesspage/chapter/10.1007/978-1-4020-8716-5_14?coverImageUrl=%2Fstatic-content%2Fcovers%2Fbooks%2F978%2F9781402087165.jpg" title="Get Access" pageType="rd_springer_com.book.chapter_denial" doi="10.1007/978-1-4020-8716-5_14" parentContentType="Book" contentType="Chapter" publication="10.1007/978-1-4020-8716-5 | Mechanosensitivity of the Nervous System" viewType="Denial">Get Access</a>
+          </span>
+        </div>
+        <div class="unlock-wrapper">
+          <div class="bar-access-restr">
+            <strong class="message">Find out how to access preview-only content</strong>
+          </div>
+        </div>
+      </div>
+    </div>
+
+        <div id="kb-nav--main" class="document-main layout-3">
+          <div id="kb-nav--main" class="col-main has-full-enumeration" role="main">
+            <div id="enumeration">
+      <div id="publication-title">
+        <a href="/book/10.1007/978-1-4020-8716-5">Mechanosensitivity of the Nervous System</a>
+      </div>
+      <a id="series-title" href="/bookseries/7878">Mechanosensitivity in Cells and Tissues</a>
+      <span id="book-volume">Volume 2, </span>
+      <span id="copyright-year">2009, </span>
+      <span id="page-range">
+        pp 299-318
+      </span>
+      
+    </div>
+
+            <h1 id="title" itemprop="headline">Exercise and Nervous System</h1>
+            <div class="author-list">
+    <ul class="authors">
+        <li class="author" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+    <a href="/search?facet-author=%22Kazuhiro+Imai%22" itemprop="name">Kazuhiro Imai</a>,
+        </li>
+        <li class="author" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+    <a href="/search?facet-author=%22Hiroyuki+Nakajima%22" itemprop="name">Hiroyuki Nakajima</a>    </li>
+        <li class="show-all-hide-authors">
+          <span class="more-authors">&hellip;</span>
+          <span class="show-all-authors">show all 2</span>
+          <span class="hide-authors">hide</span>
+        </li>
+      </ul></div>
+
+            <div id="abstract-actions">
+              <div class="box-primary content-pricing leaf-pricing">
+                <div class="leaf-pricing-content">
+                  <div class="leaf-pricing-wrapper">
+                    <h3>Purchase on Springer.com</h3>
+                    <p id="pricingInfo" class="content-prices">
+                      $29.95 / €24.95 / £19.95*
+                    </p>
+                  </div>
+                  <form id="getaccess-webshop" action="http://www.springer.com/?SGWID=0-1740713-3130-0-0&amp;wt_mc=SpringerLink-_-AbstractPage-_-EPM653-_-Chapter" method="post">
+                    <input type="hidden" name="mac" value="fccd041108219a119ae75609b08857b4"/>
+                    <input type="hidden" name="returnurl" value="http://link.springer.com/chapter/10.1007%2F978-1-4020-8716-5_14"/>
+                    <input type="hidden" name="contenttitle" value="Exercise and Nervous System"/>
+                    <input type="hidden" name="pages" value="299-318"/>
+                    <input type="hidden" name="copyrightyear" value="2009"/>
+                    <input type="hidden" name="year" value="2009"/>
+                    <input type="hidden" name="seriestitle" value="Mechanosensitivity in Cells and Tissues"/>
+                    <input type="hidden" name="authors" value="Kazuhiro Imai, Hiroyuki Nakajima"/>
+                    <input type="hidden" name="title" value="Mechanosensitivity of the Nervous System"/>
+                    <input type="hidden" name="type" value="chapter"/>
+                    <input type="hidden" name="doi" value="10.1007/978-1-4020-8716-5_14"/>
+                    <input type="hidden" name="volume" value="2"/>
+                    <input type="hidden" name="isxn" value="978-1-4020-8716-5"/>
+                    <input id="leaf-pricing-buy-now" class="btn btn-primary btn-action btn-monster" value="Buy chapter" type="submit"/>
+                  </form>
+                </div>
+                <div id="display-book-ppv">
+                  <a href="/pricing/chapter/10.1007/978-1-4020-8716-5_14">Buy this eBook</a>
+                </div>
+                <p class="price-disclaimer">* Final gross prices may vary according to local VAT.</p>
+              </div>
+              <span class="action icon-unlock">
+                <a id="request-access-link" class="webtrekk-track" href="/accesspage/chapter/10.1007/978-1-4020-8716-5_14?coverImageUrl=%2Fstatic-content%2Fcovers%2Fbooks%2F978%2F9781402087165.jpg" pageType="rd_springer_com.book.chapter_denial" doi="10.1007/978-1-4020-8716-5_14" contentType="Chapter" parentContentType="Book" viewType="Denial" publication="10.1007/978-1-4020-8716-5 | Mechanosensitivity of the Nervous System">Get Access</a>
+              </span>
+            </div>
+            <h2 class="abstract-heading">Abstract</h2>
+            <div class="abstract-content formatted" itemprop="description">
+              
+                            
+                            <p class="a-plus-plus">Voluntary physical training and exercise have favorable effects on the central nervous system and brain plasticity. The motor cortex and spinal cord possess the ability to alter structure and function in response to motor training. It is also reported that intensive training and exercise may enhance motor recovery or even restore motor function in people who have been long paralyzed due to spinal cord injury or stroke. We review the effects of exercise on the nervous system and discuss the mechanism for the exercise effects.</p>
+                          
+            </div>
+            
+          </div>
+          <div id="kb-nav--aside" class="col-aside" role="complementary">
+            <div class="cover">
+      <div class="look-inside cover-image-animate">
+        <div id="reader-overlay">
+      <div id="reader-page-template">
+        <div id="page-%P">
+          <div class="page-number">
+            Page
+            %P
+          </div>
+          <div class="pdf-page" id="page-img-container-%ID">
+            <img id="pdf-page-image-%ID" class="pdf-image" src="/static/0.7947/images/pdf-preview/spacer.gif" alt="Loading..." width="%W" style="width:%Wpx;" data-loaded="false"/>
+          </div>
+        </div>
+      </div>
+      <div class="reader-position">
+        <div id="reader">
+          <div id="reader-buttons">
+            <a href="#close" id="pdf-close" class="btn btn-close right">
+              Close
+            </a>
+            <a href="#close" id="toggletext" class="btn" title="Toggle plain text">
+              Plain text
+            </a>
+          </div>
+          <div id="viewer" class="show-pdf">
+            <div id="scroller"></div>
+          </div>
+          <div class="top-shadow"></div>
+          <div class="bottom-shadow"></div>
+        </div>
+      </div>
+    </div>
+
+        <a class="webtrekk-track lookinside-href" href="/chapter/10.1007%2F978-1-4020-8716-5_14/lookinside/000.png" pageType="rd_springer_com.book.chapter_preview" parentContentType="Book" contentType="Chapter" doi="10.1007/978-1-4020-8716-5_14" viewType="Preview" publication="10.1007/978-1-4020-8716-5 | Mechanosensitivity of the Nervous System">
+          <img class="look-inside-cover" src="/static-content/covers/books/978/9781402087165.jpg" alt="Mechanosensitivity of the Nervous System" width="153" itemprop="image"/>
+    <img class="look-inside-page" src="/static-content/lookinside/927/chp%253A10.1007%252F978-1-4020-8716-5_14/000.png" alt="Mechanosensitivity of the Nervous System" width="153" itemprop="image"/>
+
+          <span class="look-inside-badge">
+            Look
+            <br/>
+            Inside
+          </span>
+        </a>
+      </div>
+    </div>
+
+            <div class="abstract-numbers">
+              <a id="citation-link" class="abstract-numbers__citations external external-quiet hidden" target="_blank" href="http://citationsapi.nkb3.org/article/citations/count">
+                <span class="abstract-numbers__count"></span>
+                <span class="abstract-numbers__label">Citations</span>
+              </a>
+              <span class="social-mention"></span>
+            </div>
+            <div class="partner-logos">
+      <ul>
+      </ul>
+    </div>
+
+            
+            <div class="section-links">
+    </div>
+
+            <div class="other-actions">
+              <h2>Other actions</h2>
+    <ul>
+      <li>
+        <a id="export-citation" href="/export-citation/chapter/10.1007/978-1-4020-8716-5_14">
+          Export citation
+        </a>
+      </li>
+      <li>
+        <a id="about-link" class="external" href="http://www.springer.com/978-1-4020-8715-8" target="_blank" title="It opens in new window">About this Book</a>
+      </li>
+      <li>
+        <a id="permissions-link" class="external" href="https://s100.copyright.com/AppDispatchServlet?publisherName=Springer&amp;orderBeanReset=true&amp;orderSource=SpringerLink&amp;author=Kazuhiro+Imai&amp;AuthorEmail=imaik-ort%40umin.ac.jp&amp;contentID=978-1-4020-8716-5&amp;openAccess=false&amp;endPage=318&amp;publicationDate=2009&amp;startPage=299&amp;title=Exercise+and+Nervous+System&amp;imprint=Springer+Science%2BBusiness+Media+B.V.&amp;publication=eBook&amp;authorAddress=Yokohama%2C+Kanagawa%2C+Japan" target="_blank" title="It opens in new window">Reprints and Permissions</a>
+      </li>
+      <li>
+        <a id="papers-link" class="external webtrekk-track" href="http://redirect.papersapp.com/redirect?url=http://link.springer.com/chapter/10.1007%2F978-1-4020-8716-5_14" target="_blank" title="It opens in new window" gaCategory="Papers" publication="10.1007/978-1-4020-8716-5_14 | Exercise and Nervous System" viewType="Add to Papers">Add to Papers</a>
+
+      </li>
+    </ul>
+
+            </div>
+            <div class="other-actions share">
+      <h2>Share</h2>
+      <a id="facebook" href="javascript:void(0)" title="Share this content on Facebook">Share this content on Facebook</a>
+      <a id="twitter" href="javascript:void(0)" title="Share this content on Twitter">Share this content on Twitter</a>
+      <a id="linkedin" href="javascript:void(0)" title="Share this content on LinkedIn">Share this content on LinkedIn</a>
+    </div>
+
+          </div>
+        </div>
+        <div id="kb-nav--aside" class="document-aside" role="complementary">
+          <div id="abstract-related" class="hidden expander">
+      <div class="expander-title">
+        <div class="heading">
+          <button>
+            <h2>Related Content</h2>
+            <img class="hidden" src="/static/0.7947/sites/link/images/loading_expander.gif" alt="loading..."/>
+          </button>
+        </div>
+      </div>
+      <div class="expander-content">
+        <div class="expander-content-inner">
+          <ol id="related-list"></ol>
+        </div>
+      </div>
+    </div>
+
+          <div id="abstract-esm" class="expander expander-empty">
+      <div class="expander-title">
+        <div class="heading">
+          <h2>
+            <button>Supplementary Material (0)</button>
+          </h2>
+        </div>
+      </div>
+    </div>
+
+          <div id="abstract-references" class="expander">
+      <div class="expander-title">
+        <div class="heading">
+          <h2>
+            <button>References (128)</button>
+          </h2>
+        </div>
+      </div>
+      <div class="expander-content">
+        <div class="expander-content-inner">
+          <div class="formatted">
+            <ol>
+              <li>
+                <span class="authors">Aagaard P, Simonsen EB, Andersen JL et al. (2002) Neural adaptation to resistance training: changes in evoked V-wave and H-reflex responses. J Appl Physiol 92:2309–2318.</span>
+              </li>
+              <li>
+                <span class="authors">Adlard PA, Perreau VM, Pop V et al. (2005) Voluntary exercise decreases amyloid load in a transgenic model of Alzheimer’s disease. J Neurosci 25:4217–4221.</span>
+              </li>
+              <li>
+                <span class="authors">Allred RP, Jones TA (2004) Unilateral ischemic sensorimotor sortical damage in female rats: forelimb behavioral effects and dendritic structural plasticity in the contralateral homotopic cortex. Exp Neurol 190:433–445.</span>
+              </li>
+              <li>
+                <span class="authors">Alvarez GE, Halliwill JR, Ballard TP et al. (2005) sympathetic nerve regulation in endurance-trained humans: Fitness vs. fatness. J Appl Physiol 98:498–502.</span>
+              </li>
+              <li>
+                <span class="authors">Anderson BJ, Rapp DN, Baek DH et al. (2000) Exercise influences spatial learning in the radial arm maze. Physiol Behav 70:425–429.</span>
+              </li>
+              <li>
+                <span class="authors">Ang ET, Dawe GS, Wong PT et al. (2006) Alterations in spatial learning and memory after forced exercise. Brain Res 1113:186–193.</span>
+              </li>
+              <li>
+                <span class="authors">Ang ET, Wong PTH, Mochhala S et al. (2003) Neuroprotection associated with running: is it a result of increased endogenous neurotrophic factors? Neuroscience 118:335–345.</span>
+              </li>
+              <li>
+                <span class="authors">Anish EJ (2005) Exercise and its effects on the central nervous system. Curr Sports Med Rep 4:18–23.</span>
+              </li>
+              <li>
+                <span class="authors">Barnes DE, Yaffe K, Satariano WA et al. (2003) Alongitudinal study of cardiorespiratory fitness and cognitive function in healthy older adults. J Am Geriatr Soc 51:459–465.</span>
+              </li>
+              <li>
+                <span class="authors">Benedict CR, Shelton B, Johnstone DE et al. (1996) Prognostic significance of plasma norepinephrine in patients with asymptomatic left ventricular dysfunction. SOLVD Investigators. Circulation 94:690–697.</span>
+              </li>
+              <li>
+                <span class="authors">Billman GE (2002) Aerobic exercise conditioning: A nonpharmacological antiarrhythmic intervention. J Appl Physiol 92:446–454.</span>
+              </li>
+              <li>
+                <span class="authors">Blumenthal JA, Babyak MA, Moore KA et al. (1999) Effects of exercise training on older patients with major depression. Arch Intern Med 159:2349–2356.</span>
+              </li>
+              <li>
+                <span class="authors">Bramble DM, Lieberman DE (2004) Endurance running and the evolution of Homo. Nature 432:345–352.</span>
+              </li>
+              <li>
+                <span class="authors">Brosse AL, Sheets ES, Lett HS et al. (2002) Exercise and the treatment of clinical depression in adults: recent findings and future directions. Sports Med 32:741–760.</span>
+              </li>
+              <li>
+                <span class="authors">Burgess ML, Davis JM, Borg TK et al. (1991) Intracranial self-stimulation motivates treadmill running in rats. J Appl Physiol 71:1593–1597.</span>
+              </li>
+              <li>
+                <span class="authors">Carro E, Nunez A, Busiguina S et al. (2000) Circulating insulin-like growth factor 1 mediates effects of exercise on the brain. J Neurosci 20:2926–2933.</span>
+              </li>
+              <li>
+                <span class="authors">Carroll TJ, Riek S, Carson RG (2002) The sites of neural adaptation induced by resistance training in humans. J Physiol 544:641–652.</span>
+              </li>
+              <li>
+                <span class="authors">Chen CY, DiCarlo SE (1996) Daily exercise and gender influence arterial baroreflex regulation of heart rate and nerve activity. Am J Physiol 271:H1840–H1848.</span>
+              </li>
+              <li>
+                <span class="authors">Colcombe SJ, Erickson KI, Scalf PE et al. (2006) Aerobic exercise training increases brain volume in aging humans. J Gerontol A Biol Sci Med Sci 61:1166–1170.</span>
+              </li>
+              <li>
+                <span class="authors">Colcombe SJ, Kramer AF (2003) Fitness effects on the cognitive function of older adults: a meta-analysis study. Psych Sci 14:125–130.</span>
+              </li>
+              <li>
+                <span class="authors">Colcombe SJ, Kramer AF, Erickson KI et al. (2004) Cardiovascular fitness, cortical plasticity, and aging. Proc Natl Acad Sci USA 101:3316–3321.</span>
+              </li>
+              <li>
+                <span class="authors">Conner JM, Culberson A, Packowski C et al. (2003) Lesions of the basal forebrain cholinergic system impair task acquisition and abolish cortical plasticity associated with motor skill learning. Neuron 38:819–829.</span>
+              </li>
+              <li>
+                <span class="authors">Cornelissen VA, Fagard RH (2005) Effects of endurance training on blood pressure, blood pressure-regulating mechanisms, and cardiovascular risk factors. Hypertension 45:667–675.</span>
+              </li>
+              <li>
+                <span class="authors">Cotman CW, Berchtold NC (2002) Exercise: a behavioral intervention to enhance brain health and plasticity. Trends Neurosci 25:295–301.</span>
+              </li>
+              <li>
+                <span class="authors">Cotman CW, Engesser-Cesar C (2002) Exercise enhances and protects brain function. Exerc Sport Sci Rev 30:75–79.</span>
+              </li>
+              <li>
+                <span class="authors">Crameri RM, Weston AR, Rutkowski S et al. (2004) Effects of electrical stimulation leg training during the acute phase of spinal cord injury: a pilot study. Eur J Appl Physiol 83:409–415.</span>
+              </li>
+              <li>
+                <span class="authors">Czurko A, Hirase H, Csicsvari J et al. (1999) Sustained activation of hippocampal pyramidal cells by ‘space clamping’ in a running wheel. Eur J Neurosci 11:344–352.</span>
+              </li>
+              <li>
+                <span class="authors">Dalsgaard MK, Quistorff B, Danielsen ER et al. (2004) A reduced cerebral metabolic ratio in exercise reflects metabolism and not accumulation of lactate within the human brain. J Physiol 554:571–578.</span>
+              </li>
+              <li>
+                <span class="authors">De Zeeuw CI, Yeo CH (2005) Time and tide in cerebellar memory formation. Curr Opin Neurobiol 15:667–674.</span>
+              </li>
+              <li>
+                <span class="authors">DiCarlo SE, Bishop VS (1988) Exercise training attenuates baroreflex regulation of nerve activity in rabbits. Am J Physiol 255:H974–H979.</span>
+              </li>
+              <li>
+                <span class="authors">DiCarlo SE, Bishop VS (1990) Exercise training enhances cardiac afferent inhibition of baroreflex function. Am J Physiol 258:H212–H220.</span>
+              </li>
+              <li>
+                <span class="authors">Ding Y, Li J, Luan X et al. (2004) Exercise pre-conditioning reduces brain damage in ischemic rats that may be associated with regional angiogenesis and cellular overexpression of neurotrophin. Neuroscience 124:583–591.</span>
+              </li>
+              <li>
+                <span class="authors">Dishman RK, Berthoud HR, Booth FW et al. (2006) Neurobiology of exercise. Obesity 14:345–356.</span>
+              </li>
+              <li>
+                <span class="authors">Dishman RK, Washburn RA, Heath GW (2004) Physical activity epidemiology. Champaign, IL: Human Kinetics.</span>
+              </li>
+              <li>
+                <span class="authors">Döbrössy MD, Dunnett SB (2003) Motor training effects on recovery of function after striatal lesions and striatal grafts. Exp Neurol 184:274–284.</span>
+              </li>
+              <li>
+                <span class="authors">Driver HS, Taylor SR (2000) Exercise and sleep. Sleep Med Rev 4:387–402.</span>
+              </li>
+              <li>
+                <span class="authors">Dunn AL, Trivedi MH, O’Neal HA (2001) Physical activity dose-response effects on outcomes of depression and anxiety. Med Sci Sports Exerc 33:S587–S597.</span>
+              </li>
+              <li>
+                <span class="authors">Edgerton VR, Roy RR (2002) Paralysis recovery in humans and model systems. Curr Opin Neurobiol 12:658–667.</span>
+              </li>
+              <li>
+                <span class="authors">Edgerton VR, Roy RR, Allen DL et al. (2002) Adaptations in skeletal muscle disuse or decreased use atrophy. Am J Phys Med Rehab 81:S127–S147.</span>
+              </li>
+              <li>
+                <span class="authors">Edgerton VR, Tillakaratne NJ, Bigbee AJ et al. (2004) Plasticity of the spinal neural circuitry after injury. Ann Rev Neurosci 27:145–167.</span>
+              </li>
+              <li>
+                <span class="authors">Fadel PJ, Stromstad M, Hansen J et al. (2001) Arterial baroreflex control of sympathetic nerve activity during acute hypotension: Effect of fitness. Am J Physiol Heart Circ Physiol 280:H2524–H2532.</span>
+              </li>
+              <li>
+                <span class="authors">Farmer J, Zhao X, Van Praag H et al. (2004) Effects of voluntary exercise on synaptic plasticity and gene expression in the dentate gyrus of adult male Sprague-Dawley rats in vivo. Neuroscience 124:71–79.</span>
+              </li>
+              <li>
+                <span class="authors">Fischer FR, Peduzzi JD (2007) Functional recovery in rats with chronic spinal cord injuries after exposure to an enriched environment. J Spinal Cord Med 30:147–155.</span>
+              </li>
+              <li>
+                <span class="authors">Fordyce DE, Farrar RP (1991a) Enhancement of spatial learning in F344 rats by physical activity and related learning-associated alterations in hippocampal and cortical cholinergic functioning. Behav Brain Res 46:123–133.</span>
+              </li>
+              <li>
+                <span class="authors">Fordyce DE, Farrar RP (1991b) Physical effects on hippocampal and parietal cortical cholinergic function and spatial learning in F344 rats. Behav Brain Res 43:115–123.</span>
+              </li>
+              <li>
+                <span class="authors">Fox SR (1999) The influence of physical activity on mental well-being. Public Health Nutr 2:411–418.</span>
+              </li>
+              <li>
+                <span class="authors">Gandevia SC, Killian K, McKenzie DK et al. (1993) Respiratory sensations, cardiovascular control, kinesthesia, and transcranial stimulation during paralysis in humans. J Physiol 470:85–107.</span>
+              </li>
+              <li>
+                <span class="authors">Garner RP, Terracio L, Borg TK et al. (1991) Intracranial self-stimulation motivates weight-lifting exercise in rats. J Appl Physiol 71:1627–1631.</span>
+              </li>
+              <li>
+                <span class="authors">Gómez-Pinilla F, Ying Z, Roy RR et al. (2002) Voluntary exercise induces a BDNF-mediated mechanism that promotes neuroplasticity. J Neurophysiol 88:2187–2195.</span>
+              </li>
+              <li>
+                <span class="authors">Gómez-Pinilla F, Ying Z, Roy RR et al. (2004) Activity is required to maintain basal levels of neurotrophins and neuroplasticity in the spinal cord. J Neurophysiol 92:3423–3432.</span>
+              </li>
+              <li>
+                <span class="authors">Grassi G, Seravalle G, Calhoun DA et al. (1994) Physical training and baroreceptor control of sympathetic nerve activity in humans. Hypertension 23:294–301.</span>
+              </li>
+              <li>
+                <span class="authors">Graybiel AM (2005) The basal ganglia: learning new tricks and loving it. Curr Opin Neurobiol 15:638–644.</span>
+              </li>
+              <li>
+                <span class="authors">Griesbach GS, Hovda DA, Molteni R et al. (2004) Voluntary exercise following traumatic brain injury: brain-derived neurotrophic factor upregulation and recovery of function. Neuroscience 125:129–139.</span>
+              </li>
+              <li>
+                <span class="authors">Hattori S, Naoi M, Nishino H (1994) Striatal dopamine turnover during treadmill running in the rat: relation to the speed of running. Brain Res Bull 35:41–49.</span>
+              </li>
+              <li>
+                <span class="authors">Hermer-Vazquez L, Hermer-Vazquez R, Moxon KA et al. (2004) Distinct temporal activity patterns in the rat M1 and red nucleus during skilled versus unskilled limb movement. Behav Brain Res 150:93–107.</span>
+              </li>
+              <li>
+                <span class="authors">Hillman CH, Weiss EP, Hagberg JM et al. (2002) The relationship of age and cardiovascular fitness to cognitive and motor processes. Psychophysiology 39:303–312.</span>
+              </li>
+              <li>
+                <span class="authors">Ingram DK (2000) Age-related decline in physical activity: generalization to nonhumans. Med Sci Sports Exerc 32:1623–1629.</span>
+              </li>
+              <li>
+                <span class="authors">Janal MN, Colt EW, Clark WC et al. (1984) Pain sensitivity, mood and plasma endocrine levels in man following long-distance running: effects of naloxone. Pain 19:13–25.</span>
+              </li>
+              <li>
+                <span class="authors">Jensen JL, Marstrand PC, Nielsen JB (2005) Motor skill training and strength training are associated with different plastic changes in the central nervous system. J Appl Physiol 99:1558–1568.</span>
+              </li>
+              <li>
+                <span class="authors">Jones TA, Chu CJ, Grande LA (1999) Motor skills training enhances lesion-induced structural plasticity in the motor cortex of adult rats. J Neurosci 19:10153–10163.</span>
+              </li>
+              <li>
+                <span class="authors">Julius S Nesbitt S (1996) Sympathetic overactivity in hypertension. A moving target. Am J Hypertens 9:113S–120S.</span>
+              </li>
+              <li>
+                <span class="authors">Kjaer M, Secher NH, Bangsbo J et al. (1996) Hormonal and metabolic responses to electrically induced cycling during epidural anesthesia in humans. J Appl Physiol 80:2156–2162.</span>
+              </li>
+              <li>
+                <span class="authors">Kleim JA, Bruneau R, Calder K et al. (2003) Functional organization of adult motor cortex is dependent upon continued protein synthesis. Neuron 40:167–176.</span>
+              </li>
+              <li>
+                <span class="authors">Kleim JA, Cooper NR, VandenBerg PM (2002) Exercise induces angiogenesis but does not alter movement representations within rat motor cortex. Brain Res 934:1–6.</span>
+              </li>
+              <li>
+                <span class="authors">Kleim JA, Hogg TM, VandenBerg PM et al. (2004) Cortical synaptogenesis and motor map reorganization occur during late, but not early, phase of motor skill learning. J Neurosci 24:628–633.</span>
+              </li>
+              <li>
+                <span class="authors">Klintsova AY, Dickson E, Yoshida R et al. (2004) Altered expression of BDNF and its high-affinity receptor TrkB in response to complex motor learning and moderate exercise. Brain Res 1028:92–104.</span>
+              </li>
+              <li>
+                <span class="authors">Koceja DM, Davison E, Robertson CT (2004) Neuromuscular characteristics of endurance- and power-trained athletes. Res Q Exerc Sport 75:23–30.</span>
+              </li>
+              <li>
+                <span class="authors">Kramer AF, Hahn S, Cohen NJ et al. (1999) Aging, fitness and neurocognitive function. Nature 400:418–419.</span>
+              </li>
+              <li>
+                <span class="authors">Krieger EM, Brum PC, Negrao CE (1999) Influence of exercise training on neurogenic control of blood pressure in spontaneously hypertensive rats. Hypertension 34:720–723.</span>
+              </li>
+              <li>
+                <span class="authors">Krieger EM, Da Silva GJJ, Negrao CE (2001) Effects of exercise training on baroreflex control of the cardiovascular system. Ann NY Acad Sci 940:338–347.</span>
+                <a class="external" href="http://dx.doi.org/10.1111/j.1749-6632.2001.tb03689.x" target="_blank" title="It opens in new window">CrossRef</a>
+              </li>
+              <li>
+                <span class="authors">Lawlor DA, Hopker SW (2001) The effectiveness of exercise as an intervention in the management of depression: systematic review and meta-regression analysis of randomised controlled trials. Brit Med J 322:763–767.</span>
+              </li>
+              <li>
+                <span class="authors">Lee MH, Kim H, Kim SS et al. (2003) Treadmill exercise suppresses ischemia-induced increment in apoptosis and cell proliferation in hippocampal dentate gyrus of gerbils. Life sci 73:2455–2465.</span>
+              </li>
+              <li>
+                <span class="authors">Li J, Luan X, Clark JC et al. (2004) Neuroprotection against transient cerebral ischemia by exercise pre-conditioning in rats. Neurol Res 26:404–408.</span>
+              </li>
+              <li>
+                <span class="authors">MacRae PG, Spirduso WW, Walters TJ et al. (1987) Endurance training effects on striatal D2 dopamine receptor binding and striatal dopamine metabolites in presenescent older rats. Psychopharmacology 92:236–240.</span>
+              </li>
+              <li>
+                <span class="authors">Maffiuletti NA, Martin A, Babault N (2001) Electrical and mechanical H<sub class="a-plus-plus">max</sub>-to-M<sub class="a-plus-plus">max</sub> ratio in power- and endurance-trained athletes. J Appl Physiol 90:3–9.</span>
+              </li>
+              <li>
+                <span class="authors">McCloskey DP, Adamo DS, Anderson BJ (2001) Exercise increases metabolic capacity in the motor cortex and striatum, but not in the hippocampus. Brain Res 891:168–175.</span>
+              </li>
+              <li>
+                <span class="authors">Meeusen R, DeMeirlier K (1995) Exercise and brain neurotransmission. Sports Med 20:160–188.</span>
+              </li>
+              <li>
+                <span class="authors">Meeusen R, Piacentini MF, De Meirleir K (2001) Brain microdialysis in exercise research. Sports Med 31:965–983.</span>
+              </li>
+              <li>
+                <span class="authors">Meyer T, Broocks A (2000) Therapeutic impact of exercise on psychiatric disease: guidelines for exercise testing and prescription. Sports Med 30:269–279.</span>
+              </li>
+              <li>
+                <span class="authors">Monfils MH, Plautz EJ, Kleim JA (2005) In search of the motor engram: motor map plasticity as a mechanism for encoding motor experience. Neuroscientist 11:471–483.</span>
+              </li>
+              <li>
+                <span class="authors">Mueller PJ (2007) Exercise training and sympathetic nervous system activity: evidence for physical activity dependent neural plasticity. Clin Exp Pharmacol Physiol 34:377–384.</span>
+              </li>
+              <li>
+                <span class="authors">Neeper SA, Gomez-Pinilla F, Choi J et al. (1995) Exercise and brain neurotrophins. Nature 373:109.</span>
+              </li>
+              <li>
+                <span class="authors">Negrao CE, Moreira ED, Brum PC et al. (1992) Vagal and sympathetic control of heart rate during exercise by sedentary and exercise-trained rats. Braz J Med Biol Res 25:1045–1052.</span>
+              </li>
+              <li>
+                <span class="authors">Ng AV, Callister R, Johnson DG et al. (1994) Endurance exercise training is associated with elevated basal sympathetic nerve activity in healthy older humans. J Appl Physiol 77:1366–1374.</span>
+              </li>
+              <li>
+                <span class="authors">Nielsen J, Crone C, Hultborn H (1993) H-reflexes are smaller in dancers from The Royal Danish Ballet than in well-trained athletes. Eur J Appl Physiol Occup Physiol 66:116–121.</span>
+              </li>
+              <li>
+                <span class="authors">Noakes TD, St Clair Gibson A, Lambert EV (2005) From catastrophe to complexity: a novel model of integrative central neural regulation of effort and fatigue during exercise in humans: summary and conclusions. Br J Sports Med 39:120–124.</span>
+              </li>
+              <li>
+                <span class="authors">Nudo RJ, Milliken GW, Jenkins WM et al. (1996) Use-dependent alterations of movement representations in primary motor cortex of adult squirrel monkeys. J Neurosci 16:785–807.</span>
+              </li>
+              <li>
+                <span class="authors">Nybo L, Secher NH (2004) Cerebral perturbations provoked by prolonged exercise. Prog Neurobiol 72:223–261.</span>
+              </li>
+              <li>
+                <span class="authors">Oliff HS, Berchtold NC, Isackson P et al. (1998) Exercise-induced regulation of brain-derived neurotrophic factor (BDNF) transcripts in the rat hippocampus. Brain Res Mol Brain Res 61:147–153.</span>
+              </li>
+              <li>
+                <span class="authors">Paluska SA, Schwenk TL (2000) Physical activity and mental health: current concepts. Sports Med 29:167–180.</span>
+              </li>
+              <li>
+                <span class="authors">Pascual-Leone A, Nguyet D, Cohen LG et al. (1995) Modulation of muscle responses evoked by transcranial magnetic stimulation during the acquisition of new fine motor skills. J Neurophysiol 74:1037–1045.</span>
+              </li>
+              <li>
+                <span class="authors">Pearce AJ, Thickbroom GW, Byrnes ML et al. (2000) Functional reorganisation of the corticomotor projection to the hand in skilled racket players. Exp Brain Res 130:238–243.</span>
+              </li>
+              <li>
+                <span class="authors">Pereira AC, Huddleston DE, Brickman AM et al. (2007) An in vivo correlate of exercise-induced neurogenesis in the adult dentate gyrus. Proc Natl Acad Sci USA 104:5638–5643.</span>
+              </li>
+              <li>
+                <span class="authors">Perez MA, Lungholt BK, Nyborg K et al. (2004) Motor skill training induces changes in the excitability of the leg cortical area in healthy humans. Exp Brain Res 159:197–205.</span>
+              </li>
+              <li>
+                <span class="authors">Pilegaard H, Ordway GA, Saltin B et al. (2000) Transcriptional regulation of gene expression in human skeletal muscle during recovery from exercise. Am J Physiol Endocrinol Metab 279:E806–E814.</span>
+              </li>
+              <li>
+                <span class="authors">Plautz EJ, Milliken GW, Nudo RJ (2000) Effects of repetitive motor training on movement representations in adult squirrel monkeys: role of use versus learning. Neurobiol Learn Mem 74:27–55.</span>
+              </li>
+              <li>
+                <span class="authors">Ray CA, Hume KM (1998) Sympathetic neural adaptation to exercise training in humans: Insights from microneurography. Med Sci Sports Exerc 30:387–391.</span>
+              </li>
+              <li>
+                <span class="authors">Remple MS, Bruneau RM, VandenBerg PM et al. (2001) Sensitivity of cortical movement representations to motor experience: evidence that skill learning but not strength training induces cortical reorganization. Behav Brain Res 123:133–141.</span>
+              </li>
+              <li>
+                <span class="authors">Rhodes JS, van Praag H, Jeffrey S et al. (2003) Exercise increases hippocampal neurogenesis to high levels but does not improve spatial learning in mice bred for increased voluntary wheel running. Behav Neurosci 117:1006–1016.</span>
+              </li>
+              <li>
+                <span class="authors">Robertson MC, Campbell AJ, Gardner MM et al. (2002) Preventing injuries in older people by preventing falls: a meta-analysis of individual-level data. J Am Geriatric Soc 50:905–911.</span>
+              </li>
+              <li>
+                <span class="authors">Salamone JD, Correa M, Mingote S et al. (2003) Nucleus accumbens dopamine and the regulation of effort in food-seeking behavior: implications for studies of natural motivation, psychiatry, and drug abuse. J Pharm Exp Therap 305:1–8.</span>
+              </li>
+              <li>
+                <span class="authors">Sale DG, MacDougall JD, Upton AR et al. (1983) Effect of strength training upon motoneuron excitability in man. Med Sci Sports Exerc 15:57–62.</span>
+              </li>
+              <li>
+                <span class="authors">Schlaich MP, Lambert E, Kaye D et al. (2004) Sympathetic augmentation in hypertension. Role of nerve firing, norepinephrine reuptake, and angiotensin neuromodulation. Hypertension 43:169–175.</span>
+              </li>
+              <li>
+                <span class="authors">Smith AD, Zigmond MJ (2003) Can the brain be protected through exercise? Lessons from an animal model of parkinsonism. Exp Neurol 184:31–39.</span>
+              </li>
+              <li>
+                <span class="authors">Stummer W, Weber K, Tranmer B et al. (1994) Reduced mortality and brain damage after locomotor activity in gerbil forebrain ischemia. Stroke 25:1862–1869.</span>
+              </li>
+              <li>
+                <span class="authors">Svensson P, Romaniello A, Arendt-Nielsen L et al. (2003) Plasticity in corticomotor control of the human tongue musculature induced by tongue-task training. Exp Brain Res 152:42–51.</span>
+              </li>
+              <li>
+                <span class="authors">Swain RA, Harris AB, Wiener EC et al. (2003) Prolonged exercise induces angiogenesis and increases cerebral blood volume in primary motor cortex of the rat. Neuroscience 117:1037–1046.</span>
+              </li>
+              <li>
+                <span class="authors">Tillakaratne NJK, de Leon RD, Hoang T et al. (2002) Use-dependent modulation of inhibitory capacity in the feline lumbar spinal cord. J Neurosci 22:3130–3143.</span>
+              </li>
+              <li>
+                <span class="authors">Timoszyk WK, de Leon RD, London N (2002) The rat lumbosacral spinal cord adapts to robotic loading applied during stance. J Neurophysiol 88:3108–3117.</span>
+              </li>
+              <li>
+                <span class="authors">Tipton CM (1991) Exercise, training, and hypertension: An update. Exerc Sport Sci Rev 19:447–505.</span>
+              </li>
+              <li>
+                <span class="authors">Tyc F, Boyadjian A, Devanne H (2005) Motor cortex plasticity induced by extensive training revealed by transcranial magnetic stimulation in human. Eur J Neurosci 21:259–266.</span>
+              </li>
+              <li>
+                <span class="authors">Ung RV, Imbeault MA, Ethier C et al. (2005) On the potential role of the corticospinal tract in the control and progressive adaptation of the soleus H-reflex during backward walking. J Neurophysiol 94:1133–1142.</span>
+              </li>
+              <li>
+                <span class="authors">U.S. Department of Health and Human Services (1996) Physical activity and health: a report of the surgeon general. Atlanta, GA: U.S. Department of Health and Human Services, Centers for Disease Control and Prevention, National Center for Chronic Disease Prevention and Health Promotion.</span>
+              </li>
+              <li>
+                <span class="authors">VandenBerg PM, Bruneau RM, Thomas N et al. (2004) BDNF is required for maintaining motor map integrity in adult cerebral cortex. Soc Neurosci Abstr 681</span>
+              </li>
+              <li>
+                <span class="authors">van Gelder BM, Tijhuis MA, Kalmijn S et al. (2004) Physical activity in relation to cognitive decline in elderly men: the FINE study. Neurology 63:2316–2321.</span>
+              </li>
+              <li>
+                <span class="authors">van Praag H, Christie BR, Sejnowski TJ et al. (1999) Running enhances neurogenesis, learning, and long-term potentiation in mice. Proc Natl Acad Sci USA 96:13427–13431.</span>
+              </li>
+              <li>
+                <span class="authors">van Praag H, Kempermann G, Gage FH (1999) Running increases cell proliferation and neurogenesis in the adult mouse dentate gyrus. Nature Neurosci 2:266–270.</span>
+              </li>
+              <li>
+                <span class="authors">Vaynman S (2005) License to run: exercise impacts functional plasticity in the intact and injured central nervous system by using neurotrophins. Neurorehabil Neural Repair 19:283–295.</span>
+              </li>
+              <li>
+                <span class="authors">Vaynman S, Ying Z, Gómez-Pinilla F (2004) Hippocampal BDNF mediates the efficacy of exercise on synaptic plasticity and cognition. Eur J Neurosci 20:2580–2590.</span>
+              </li>
+              <li>
+                <span class="authors">Vaynman S, Ying Z, Wu A et al. (2006) Coupling energy metabolism with a mechanism to support brain-derived neurotrophic factor-mediated synaptic plasticity. Neuroscience 139:1221–1234.</span>
+              </li>
+              <li>
+                <span class="authors">Vissing J, Andersen M, Diemer NH (1996) Exercise-induced changes in local cerebral glucose utilization in the rat. J Cerebral Blood Flow Metab 16:729–736.</span>
+              </li>
+              <li>
+                <span class="authors">Wang GJ, Volkow ND, Fowler JS et al. (2000) PET studies of the effects of aerobic exercise on human striatal dopamine release. J Nuclear Med 41:1352–1356.</span>
+              </li>
+              <li>
+                <span class="authors">Weuve J, Kang JH, Manson JE et al. (2004) Physical activity, including walking, and cognitive function in older women. JAMA 292:1454–1461.</span>
+              </li>
+              <li>
+                <span class="authors">Williamson JW, McColl R, Mathews D (2003) Evidence for central command activation of the human insular cortex during exercise. J Appl Physiol 94:1726–1734.</span>
+              </li>
+              <li>
+                <span class="authors">Williamson JW, McColl R, Mathews D et al. (2001) Hypnotic manipulation of effort sense during dynamic exercise: cardiovascular responses and brain activation. J Appl Physiol 90:1392–1399.</span>
+              </li>
+              <li>
+                <span class="authors">Williamson JW, Nobrega AC, McColl R et al. (1997) Activation of the insular cortex during dynamic exercise in humans. J Physiol 503:277–283.</span>
+              </li>
+              <li>
+                <span class="authors">Wolpaw JR, Lee CL (1989) Memory traces in primate spinal cord produced by operant conditioning of H-reflex. J Neurophysiol 61:563–572.</span>
+              </li>
+              <li>
+                <span class="authors">Zucker IH, Patel KP, Schultz HD et al. (2004) Exercise training and sympathetic regulation in experimental heart failure. Exerc Sport Sci Rev 32:107–111.</span>
+              </li>
+            </ol>
+          </div>
+        </div>
+      </div>
+    </div>
+
+          <div id="abstract-about" class="expander expander-open">
+      <div class="expander-title">
+        <div class="heading">
+          <button>
+            <h2>About this Chapter</h2>
+          </button>
+        </div>
+      </div>
+      <div class="expander-content">
+        <div class="expander-content-inner">
+          <div class="summary">
+            <dl>
+              <dt>Title</dt>
+              <dd id="abstract-about-title">Exercise and Nervous System</dd>
+              
+              <dt>Book Title</dt>
+              <dd id="abstract-about-publication">
+                <a href="/book/10.1007/978-1-4020-8716-5">Mechanosensitivity of the Nervous System</a>
+              </dd>
+              <dt id="dt-abstract-about-book-subtitle">Book Subtitle</dt>
+    <dd id="abstract-about-book-subtitle">Forewords by Nektarios Tavernarakis and Pontus Persson</dd>
+
+              <dt id="dt-abstract-about-book-chapter-part-number">Book Part</dt>
+    <dd id="abstract-about-book-chapter-part-number">Part III</dd>
+
+              <dt id="dt-abstract-about-book-chapter-page-ranges">Pages</dt>
+    <dd id="abstract-about-book-chapter-page-ranges">pp 299-318</dd>
+
+              <dt id="dt-abstract-about-book-chapter-copyright-year">Copyright</dt>
+    <dd id="abstract-about-book-chapter-copyright-year">2009</dd>
+
+              <dt>DOI</dt>
+              <dd id="abstract-about-book-chapter-doi" class="doi">10.1007/978-1-4020-8716-5_14</dd>
+              <dt id="dt-abstract-about-book-print-isbn">Print ISBN</dt>
+    <dd id="abstract-about-book-print-isbn">978-1-4020-8715-8</dd>
+
+              <dt id="dt-abstract-about-book-online-isbn">Online ISBN</dt>
+    <dd id="abstract-about-book-online-isbn">978-1-4020-8716-5</dd>
+
+              <dt id="dt-abstract-about-book-series-title">Series Title</dt>
+    <dd id="abstract-about-book-series-title">
+      <a href="/bookseries/7878">Mechanosensitivity in Cells and Tissues</a>
+    </dd>
+
+              <dt id="dt-abstract-about-book-series-volume">Series Volume</dt>
+    <dd id="abstract-about-book-series-volume">2</dd>
+
+              
+              
+              <dt id="dt-abstract-about-publisher">Publisher</dt>
+    <dd id="abstract-about-publisher">Springer Netherlands</dd>
+
+              <dt id="dt-abstract-about-book-copyright-holder">Copyright Holder</dt>
+    <dd id="abstract-about-book-copyright-holder">Springer Science+Business Media B.V.</dd>
+
+              <dt>Additional Links</dt>
+              <dd id="abstract-about-additional-links">
+                <ul>
+                  <li>
+                    <a class="external" href="http://www.springer.com/978-1-4020-8715-8" target="_blank" title="It opens in new window">About this Book</a>
+                  </li>
+                </ul>
+              </dd>
+            </dl>
+            <dl>
+      <dt>Topics</dt>
+    <dd itemprop="genre">
+      <ul class="abstract-about-subject">
+        <li>
+          <a href="/search?facet-subject=%22Biochemistry%2C+general%22">Biochemistry, general</a>
+        </li>
+        <li>
+          <a href="/search?facet-subject=%22Neurosciences%22">Neurosciences</a>
+        </li>
+        <li>
+          <a href="/search?facet-subject=%22Neurology%22">Neurology</a>
+        </li>
+        <li>
+          <a href="/search?facet-subject=%22Cell+Biology%22">Cell Biology</a>
+        </li>
+        <li>
+          <a href="/search?facet-subject=%22Neuroradiology%22">Neuroradiology</a>
+        </li>
+      </ul>
+    </dd>
+
+      <dt>Keywords</dt>
+    <dd id="abstract-about-keywords" itemprop="keywords">
+      <ul class="abstract-keywords">
+        <li>Exercise</li>
+        <li>Physical activity</li>
+        <li>Central nervous system</li>
+        <li>Brain plasticity</li>
+        <li>Sympathetic nervous system</li>
+        <li>Corticospinal plasticity</li>
+      </ul>
+    </dd>
+
+      <dt>Industry Sectors</dt>
+    <dd itemprop="genre">
+      <ul class="abstract-about-industrysectors">
+        <li>
+          <a title="/industry/biotech" href="/industry/biotech">Biotechnology</a>
+        </li>
+        <li>
+          <a title="/industry/health" href="/industry/health">Health &amp; Hospitals</a>
+        </li>
+        <li>
+          <a title="/industry/chemicals" href="/industry/chemicals">Chemical Manufacturing</a>
+        </li>
+        <li>
+          <a title="/industry/consumer" href="/industry/consumer">Consumer Packaged Goods</a>
+        </li>
+        <li>
+          <a title="/industry/pharma" href="/industry/pharma">Pharma</a>
+        </li>
+      </ul>
+    </dd>
+
+      <dt>eBook Packages</dt>
+    <dd itemprop="genre">
+      <ul class="abstract-about-ebook-packages">
+        <li>
+          <a href="/search?package=90011652">eBook Package english full Collection</a>
+        </li>
+        <li>
+          <a href="/search?package=11642">eBook Package english Biomedicine &amp; Life Sciences</a>
+        </li>
+      </ul>
+    </dd>
+
+    </dl>
+    <dl>
+      <dt>Editors</dt>
+    <dd>
+      <ul class="editors">
+        <li itemprop="editor" itemscope="itemscope" itemtype="http://schema.org/Person">
+          <a class="person" href="/search?facet-author=%22Andre+Kamkim%22" itemprop="name">Andre Kamkim</a>
+          <a class="envelope" href="mailto:Kamkin.A@g23.relcom.ru" title="Kamkin.A@g23.relcom.ru"><img src="/static/0.7947/images/envelope.png" alt="Kamkin.A@g23.relcom.ru"/></a>
+          <sup title="Dept. Fundamental &amp; Applied Physiology, Russian State Medical University">(3)</sup>
+        </li>
+        <li itemprop="editor" itemscope="itemscope" itemtype="http://schema.org/Person">
+          <a class="person" href="/search?facet-author=%22Irina+Kiseleva%22" itemprop="name">Irina Kiseleva</a>
+          <sup title="Dept. Fundamental &amp; Applied Physiology, Russian State Medical University">(3)</sup>
+        </li>
+      </ul>
+    </dd>
+    <dt>Editor Affiliations</dt>
+    <dd>
+      <ul class="editor-affiliations">
+        <li>
+          <span class="position">3.</span>
+          <span class="affiliation">
+            Dept. Fundamental &amp; Applied Physiology, Russian State Medical University
+          </span>
+        </li>
+      </ul>
+    </dd>
+
+      <dt>Authors</dt>
+    <dd>
+      <ul class="authors">
+        <li itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+          <a class="person" href="/search?facet-author=%22Kazuhiro+Imai%22" itemprop="name">Kazuhiro Imai</a>
+          <a class="envelope" href="mailto:imaik-ort@umin.ac.jp" title="imaik-ort@umin.ac.jp"><img src="/static/0.7947/images/envelope.png" alt="imaik-ort@umin.ac.jp"/></a>
+          <sup title="Department of Orthopaedic Surgery, Yokohama Sports Medical Center, Nissan Stadium, 3302-5, Kotsukue-cho, Kohoku-ku">(4)</sup>
+        </li>
+        <li itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
+          <a class="person" href="/search?facet-author=%22Hiroyuki+Nakajima%22" itemprop="name">Hiroyuki Nakajima</a>
+        </li>
+      </ul>
+    </dd>
+    <dt>Author Affiliations</dt>
+    <dd>
+      <ul class="author-affiliations">
+        <li>
+          <span class="position">4.</span>
+          <span class="affiliation">
+            Department of Orthopaedic Surgery, Yokohama Sports Medical Center, Nissan Stadium, 3302-5, Kotsukue-cho, Kohoku-ku, Yokohama, Kanagawa, Japan
+            
+          </span>
+        </li>
+      </ul>
+    </dd>
+
+    </dl>
+
+          </div>
+        </div>
+      </div>
+    </div>
+
+        </div>
+      </div>
+      <div id="look-inside-interrupt" class="look-inside-interrupt">
+      <h3>Continue reading...</h3>
+      <div class="col-1">
+        <p>To view the rest of this content please follow the download PDF link above.</p>
+      </div>
+    </div>
+
+    </div>
+    <div id="web-trekk-abstract" doi="10.1007/978-1-4020-8716-5_14" parentContentType="Book" contentType="Chapter" viewType="Abstract" publication="10.1007/978-1-4020-8716-5 | Mechanosensitivity of the Nervous System"></div>
+
+
+    <div id="footer">
+  <hr/>
+  <div id="footer-verticals" class="section" role="navigation">
+    <span class="strapline">Over 8.5 million scientific documents at your fingertips</span>
+    <div class="flyout">
+      <button class="pillow-btn open-disciplines">
+        Browse by Discipline
+        <span class="caret"></span>
+      </button>
+      <ol class="disciplines">
+  <li>
+    <a href="/search?facet-discipline=&quot;Architecture+%26+Design&quot;" title="follow this link to go to Architecture &amp; Design">Architecture &amp; Design</a>
+  </li>
+  <li>
+    <a href="/search?facet-discipline=&quot;Astronomy&quot;" title="follow this link to go to Astronomy">Astronomy</a>
+  </li>
+  <li>
+    <a href="/search?facet-discipline=&quot;Biomedical+Sciences&quot;" title="follow this link to go to Biomedical Sciences">Biomedical Sciences</a>
+  </li>
+  <li>
+    <a href="/search?facet-discipline=&quot;Business+%26+Management&quot;" title="follow this link to go to Business &amp; Management">Business &amp; Management</a>
+  </li>
+  <li>
+    <a href="/search?facet-discipline=&quot;Chemistry&quot;" title="follow this link to go to Chemistry">Chemistry</a>
+  </li>
+  <li>
+    <a href="/search?facet-discipline=&quot;Computer+Science&quot;" title="follow this link to go to Computer Science">Computer Science</a>
+  </li>
+  <li>
+    <a href="/search?facet-discipline=&quot;Earth+Sciences+%26+Geography&quot;" title="follow this link to go to Earth Sciences &amp; Geography">Earth Sciences &amp; Geography</a>
+  </li>
+  <li>
+    <a href="/search?facet-discipline=&quot;Economics&quot;" title="follow this link to go to Economics">Economics</a>
+  </li>
+  <li>
+    <a href="/search?facet-discipline=&quot;Education+%26+Language&quot;" title="follow this link to go to Education &amp; Language">Education &amp; Language</a>
+  </li>
+  <li>
+    <a href="/search?facet-discipline=&quot;Energy&quot;" title="follow this link to go to Energy">Energy</a>
+  </li>
+  <li>
+    <a href="/search?facet-discipline=&quot;Engineering&quot;" title="follow this link to go to Engineering">Engineering</a>
+  </li>
+  <li>
+    <a href="/search?facet-discipline=&quot;Environmental+Sciences&quot;" title="follow this link to go to Environmental Sciences">Environmental Sciences</a>
+  </li>
+  <li>
+    <a href="/search?facet-discipline=&quot;Food+Science+%26+Nutrition&quot;" title="follow this link to go to Food Science &amp; Nutrition">Food Science &amp; Nutrition</a>
+  </li>
+  <li>
+    <a href="/search?facet-discipline=&quot;Law&quot;" title="follow this link to go to Law">Law</a>
+  </li>
+  <li>
+    <a href="/search?facet-discipline=&quot;Life+Sciences&quot;" title="follow this link to go to Life Sciences">Life Sciences</a>
+  </li>
+  <li>
+    <a href="/search?facet-discipline=&quot;Materials&quot;" title="follow this link to go to Materials">Materials</a>
+  </li>
+  <li>
+    <a href="/search?facet-discipline=&quot;Mathematics&quot;" title="follow this link to go to Mathematics">Mathematics</a>
+  </li>
+  <li>
+    <a href="/search?facet-discipline=&quot;Medicine&quot;" title="follow this link to go to Medicine">Medicine</a>
+  </li>
+  <li>
+    <a href="/search?facet-discipline=&quot;Philosophy&quot;" title="follow this link to go to Philosophy">Philosophy</a>
+  </li>
+  <li>
+    <a href="/search?facet-discipline=&quot;Physics&quot;" title="follow this link to go to Physics">Physics</a>
+  </li>
+  <li>
+    <a href="/search?facet-discipline=&quot;Psychology&quot;" title="follow this link to go to Psychology">Psychology</a>
+  </li>
+  <li>
+    <a href="/search?facet-discipline=&quot;Public+Health&quot;" title="follow this link to go to Public Health">Public Health</a>
+  </li>
+  <li>
+    <a href="/search?facet-discipline=&quot;Social+Sciences&quot;" title="follow this link to go to Social Sciences">Social Sciences</a>
+  </li>
+  <li>
+    <a href="/search?facet-discipline=&quot;Statistics&quot;" title="follow this link to go to Statistics">Statistics</a>
+  </li>
+</ol>
+
+    </div>
+  </div>
+  <div id="footer-nav" class="section">
+    <div id="footer-nav-misc">
+      <div id="footer-our-content" class="block" role="navigation">
+        <h2>Our Content</h2>
+        <ul>
+          <li>
+            <a title="View Journals" href="/search?facet-content-type=%22Journal%22">Journals</a>
+          </li>
+          <li>
+            <a title="View Books" href="/search?facet-content-type=%22Book%22">Books</a>
+          </li>
+          <li>
+            <a title="View Book Series" href="/search?facet-content-type=%22BookSeries%22">Book Series</a>
+          </li>
+          <li>
+            <a title="View Protocols" href="/search?facet-content-type=%22Protocol%22">Protocols</a>
+          </li>
+          <li>
+            <a title="View Reference Works" href="/search?facet-content-type=%22ReferenceWork%22">Reference Works</a>
+          </li>
+        </ul>
+      </div>
+      <div id="footer-other-sites" class="block" role="navigation">
+        <h2>Other Sites</h2>
+        <ul>
+          <li>
+            <a title="Visit Springer.com" href="http://www.springer.com/">Springer.com</a>
+          </li>
+          <li>
+            <a title="Visit Springer Images" href="http://www.springerimages.com/">SpringerImages</a>
+          </li>
+          <li>
+            <a title="Visit Springer Protocols" href="http://www.springerprotocols.com/">SpringerProtocols</a>
+          </li>
+          <li>
+            <a title="Visit Springer Materials" href="http://www.springermaterials.com/">SpringerMaterials</a>
+          </li>
+          <li>
+            <a title="Visit Springer Reference" href="http://www.springerreference.com/">SpringerReference</a>
+          </li>
+        </ul>
+      </div>
+      <div class="block" role="navigation">
+        <h2>Help &amp; Contacts</h2>
+        <ul>
+          <li>
+            <a class="contact-us-link" title="Contact us" href="/contactus">Contact Us</a>
+          </li>
+          <li>
+            <a class="feedback-community-link" title="Visit the Feedback Community" href="http://feedback.rd.springer.com/springer_rd">Feedback Community</a>
+          </li>
+          <li>
+            <a class="impressum-link" title="View Impressum" href="/impressum">Impressum</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div id="footer-legal" class="section" role="contentinfo">
+    <div id="mobile-nav">
+      <span class="pillow-btn open-legal" title="Show Legal Information">Legal</span>
+    </div>
+    <div id="legal" role="contentinfo">
+      <span id="footer-copyright">&copy; Springer, Part of Springer Science+Business Media</span>
+      <a id="footer-privacy" title="View Terms and Conditions" href="/termsandconditions">Privacy Policy, Disclaimer, General Terms &amp; Conditions</a>
+      <div id="diagnostic-info">
+  <span id="diagnostic-login-status">Not logged in</span>
+  <span class="diagnostic-business-partners">Unaffiliated</span>
+  <span id="diagnostic-ip">209.112.41.10</span>
+</div>
+
+      
+    </div>
+  </div>
+  <div id="footer-branding" class="section">
+    <div class="block">
+      <span id="branding-logo">Springer for Research &amp; Development</span>
+    </div>
+  </div>
+  <div id="google-analytics-account" style="display: none">UA-26408784-1</div>
+</div>
+
+
+    <div id="doubleclick-ad" class="banner-advert">
+  <script type="text/javascript">if ( window.outerWidth || document.body.clientWidth > 1100 ) { googletag.cmd.push(function() { googletag.display('doubleclick-ad'); }); };</script>
+</div>
+
+  </div>
+  <noscript>
+  <div id="jsnotice" class="prompt-bar">
+    <p>
+      JavaScript is currently disabled<span>, this site works much better if you enable JavaScript in your browser.</span>
+    </p>
+  </div>
+</noscript>
+<script src="/static/js/webtrekk/webtrekk_v3.js"></script>
+<script type="text/javascript">
+  var webtrekkProperties = {
+  trackDomain : "springergmbh01.webtrekk.net",
+  trackId : "935649882378213",
+  pageType : "rd_springer_com.book.chapter_abstract"
+  };
+</script>
+<noscript>
+  <div id="webtrekk">
+    <img src="http://springergmbh01.webtrekk.net/935649882378213/wt?p=315,rd_springer_com.book.chapter_abstract" height="1" width="1" alt=""/>
+  </div>
+</noscript>
+
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+<script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js"></script>
+<script src="http://code.jquery.com/jquery-migrate-1.2.1.js"></script>
+<script type="text/javascript">
+  var springerImagesProperties = {
+  apiUrl: '2014/04/15'
+  };
+  var vgWortProperties = {
+  vgWortDomain: 'springer.met.vgwort.de'
+  };
+  var inDevelopment = false;
+</script>
+<script src="/static/0.7947/js/all.js"></script>
+<script type="text/x-mathjax-config">
+  MathJax.Hub.Config({
+    /* load MathML extension */
+    extensions: ["mml2jax.js"],
+
+    /* configure input and output */
+    jax: ["input/TeX", "input/MathML", "output/HTML-CSS"],
+
+    /* align display equations to the left */
+    displayAlign: "left",
+
+    /* set zoom trigger */
+    menuSettings: {
+      zoom: "Click"
+    },
+
+    /* configuration of the tex2jax preprocessor:
+       - set delimiters for inline and display equations
+       - preview while equations are processed is "TeX"
+       - allow \$ to represent a literal dollar sign
+     */
+    tex2jax: {
+      inlineMath: [ ['$','$'], ["\\(","\\)"] ],
+      displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
+      preview: ["TeX"],
+      processEscapes: true
+    },
+
+    /* configuration of the mml2jax preprocessor:
+       - preview while equations are processed is "MathML"
+     */
+    mml2jax: {
+      preview: ["MathML"]
+    },
+
+    /* configuration of the HTML-CSS output processor:
+       - available fonts are STIX and TeX
+       - preferred font is STIX
+       - use TeX as web-based font if none of the above is available on the user's computer
+       - use TeX font for image fallback mode
+    */
+    "HTML-CSS": {
+        EqnChunk: 500,
+        EqnChunkFactor: 1,
+        EqnChunkDelay: 1000,
+        availableFonts: ["STIX", "TeX"],
+        preferredFont: ["STIX"],
+        webFont: ["TeX"],
+        imageFont: ["TeX"],
+        styles: {
+            '.MathJax_Display': {
+                "margin": 0
+            },
+            '#MathJax_Message': {
+                "margin": 0
+            }
+        }
+    },
+    TeX: {
+
+      TagSide: "right",
+
+      Macros: {
+          bgroup: '{\\unicode{x007B}}',
+
+          egroup: '{\\unicode{x007D}}',
+
+          enskip: '{\\enspace}',
+
+          parbox: ['\\mbox{#2}',2],
+
+          upvarepsilon: '{\\unicode{x03B5}}',
+
+          ss: '{\\unicode{x1E9E}}',
+
+          Upgamma: '{\\unicode{x0393}}',
+
+          upgamma: '{\\unicode{x03B3}}',
+
+          Updelta: '{\\unicode{x0394}}',
+
+          updelta: '{\\unicode{x03B4}}',
+
+          Uptheta: '{\\unicode{x0398}}',
+
+          uptheta: '{\\unicode{x03B8}}',
+
+          Upkappa: '{\\unicode{x039A}}',
+
+          upkappa: '{\\unicode{x03BA}}',
+
+          Uplambda: '{\\unicode{x039B}}',
+
+          uplambda: '{\\unicode{x03BB}}',
+
+          Upsigma: '{\\unicode{x03A3}}',
+
+          upsigma: '{\\unicode{x03C3}}',
+
+          Upmu: '{\\unicode{x039C}}',
+
+          upmu: '{\\unicode{x03BC}}',
+
+          Upiota: '{\\unicode{x0399}}',
+
+          upiota: '{\\unicode{x03B9}}',
+
+          Upnu: '{\\unicode{x039D}}',
+
+          upnu: '{\\unicode{x03BD}}',
+
+          Upxi: '{\\unicode{x039E}}',
+
+          upxi: '{\\unicode{x03BE}}',
+
+          Upomicron: '{\\unicode{x039F}}',
+
+          upomicron: '{\\unicode{x03BF}}',
+
+          Uppi: '{\\unicode{x03A0}}',
+
+          uppi: '{\\unicode{x03C0}}',
+
+          Uprho: '{\\unicode{x03A1}}',
+
+          uprho: '{\\unicode{x03C1}}',
+
+          Uptau: '{\\unicode{x03A4}}',
+
+          uptau: '{\\unicode{x03C4}}',
+
+          Upupsilon: '{\\unicode{x03A5}}',
+
+          upupsilon: '{\\unicode{x03C5}}',
+
+          Upphi: '{\\unicode{x03A6}}',
+
+          upphi: '{\\unicode{x03C6}}',
+
+          Upchi: '{\\unicode{x03A7}}',
+
+          upchi: '{\\unicode{x03C7}}',
+
+          Uppsi: '{\\unicode{x03A8}}',
+
+          uppsi: '{\\unicode{x03C8}}',
+
+          Upomega: '{\\unicode{x03A9}}',
+
+          upomega: '{\\unicode{x03C9}}',
+
+          upalpha: '{\\unicode{x03B1}}',
+
+          upbeta: '{\\unicode{x03B2}}',
+
+          upepsilon: '{\\unicode{x03B5}}',
+
+          upzeta: '{\\unicode{x03B6}}',
+
+          upeta: '{\\unicode{x03B7}}',
+
+          permille: '{\\unicode{x2030}}',
+
+          hfill: '{\\enspace\\enspace}',
+
+          copyright: '{\\unicode{x00A9}}',
+
+          dag: '{\\unicode{x2020}}',
+
+          ddag: '{\\unicode{x2021}}',
+
+          ointop: '{\\unicode{0x222E}}',
+
+          P: '{\\unicode{0x00B6}}',
+
+          lhook: '{\\hookrightarrow}',
+
+          rhook: '{\\hookleftarrow}',
+
+          fancyscript: ['{\\scr #1}', 1],
+
+          varvec: ['\\pmb{#1}', 1]
+
+      }
+    },
+    /* configuration of the math menu:
+       - allow the user to select what font to use
+    */
+    MathMenu: {
+      showFontMenu: true
+    }
+  });
+
+</script>
+<script src="http://rd.springer.com/mathjax/v2.2/MathJax.js?config=TeX-AMS_HTML-full.js"></script>
+<script src="/static/0.7947/js/internal/mathJaxHooks.js"></script>
+
+<script type="text/javascript">
+  var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', 'UA-26408784-1']);
+  _gaq.push (['_gat._anonymizeIp']);
+  _gaq.push(['_trackPageview']);
+  (function() {
+  var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+  ga.src = ('https:' === document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+  var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();
+</script>
+
+
+<div id="gimme-satisfaction"></div>
+<script type="text/javascript">var _kiq = _kiq || [];</script>
+<script type="text/javascript" src="//s3.amazonaws.com/ki.js/47412/9CC.js" async="true"></script>
+
+
+</body>
+</html>

--- a/oabutton/phantomjs/tests.py
+++ b/oabutton/phantomjs/tests.py
@@ -36,3 +36,18 @@ class TestEmails(TestCase):
     def test_springerlink(self):
         emails = scrape_email(self.get_url('springerlink.html'))
         self.assertEquals(set(['kamkin.a@g23.relcom.ru', 'imaik-ort@umin.ac.jp']), emails)
+
+    def test_only_email_if_no_block(self):
+        url = self.get_url('springerlink.html')
+
+        from oabutton.apps.bookmarklet.models import OABlockedURL
+        record = OABlockedURL.objects.create(slug='foo',
+                                             author_email='kamkin.a@g23.relcom.ru',
+                                             blocked_url=url)
+        record.save()
+        record = OABlockedURL.objects.create(slug='bar',
+                                             author_email='imaik-ort@umin.ac.jp',
+                                             blocked_url=url)
+        record.save()
+        emails = scrape_email(url)
+        self.assertEquals(set(), emails)

--- a/oabutton/phantomjs/tests.py
+++ b/oabutton/phantomjs/tests.py
@@ -19,19 +19,19 @@ class TestEmails(TestCase):
 
     def test_sciencemag_org(self):
         emails = scrape_email(self.get_url('sciencemag.html'), "stke.sciencemag.org")
-        assert set(['gelvin@purdue.edu']) == emails
+        self.assertEquals(set(['gelvin@purdue.edu']), emails)
 
     def test_plos(self):
         emails = scrape_email(self.get_url('plos.html'), "www.plosone.org")
-        assert set(['chenfh@wfu.edu']) == emails
+        self.assertEquals(set(['chenfh@wfu.edu']), emails)
 
     def test_thirdbit(self):
         emails = scrape_email(self.get_url('third-bit.html'), 'www.third-bit.com')
-        assert set(['gvwilson@third-bit.com']) == emails
+        self.assertEquals(set(['gvwilson@third-bit.com']), emails)
 
     def test_plus_addresses(self):
         emails = scrape_email(self.get_url('plus.html'), 'www.third-bit.com')
-        assert set(['gvwilson+oabutton@third-bit.com']) == emails
+        self.assertEquals(set(['gvwilson+oabutton@third-bit.com']), emails)
 
     def test_springerlink(self):
         emails = scrape_email(self.get_url('springerlink.html'))

--- a/oabutton/phantomjs/tests.py
+++ b/oabutton/phantomjs/tests.py
@@ -35,4 +35,4 @@ class TestEmails(TestCase):
 
     def test_springerlink(self):
         emails = scrape_email(self.get_url('springerlink.html'))
-        self.assertEquals(set(['kamkin.a@g23.relcom', 'imaik-ort@umin.ac']), emails)
+        self.assertEquals(set(['kamkin.a@g23.relcom.ru', 'imaik-ort@umin.ac.jp']), emails)

--- a/oabutton/phantomjs/tests.py
+++ b/oabutton/phantomjs/tests.py
@@ -32,3 +32,7 @@ class TestEmails(TestCase):
     def test_plus_addresses(self):
         emails = scrape_email(self.get_url('plus.html'), 'www.third-bit.com')
         assert set(['gvwilson+oabutton@third-bit.com']) == emails
+
+    def test_springerlink(self):
+        emails = scrape_email(self.get_url('springerlink.html'))
+        self.assertEquals(set(['kamkin.a@g23.relcom', 'imaik-ort@umin.ac']), emails)

--- a/oabutton/settings.py
+++ b/oabutton/settings.py
@@ -21,6 +21,7 @@ HOSTNAME = 'http://localhost:8000'
 DB_USER = 'postgres'
 DB_HOST = 'localhost'
 SECRET_KEY = 'some_secrete_clobbered_by_settings_local'
+OABUTTON_EMAIL = 'some_fake_email@some.fake.host.com'
 # End override vars
 
 try:


### PR DESCRIPTION
This is a giant patch.  apologies.

This adds email detection via phantomjs to parse out author email addresses and allows authors to submit open links back to the OAButton.

Open links are visible on subsequent use of the button on a paywall page. 
